### PR TITLE
Drift Refactoring introduce nodeclass static field drift

### DIFF
--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -26,14 +26,21 @@ func init() {
 }
 
 var (
-	Group              = "oci.oraclecloud.com"
-	NodeClassHash      = Group + "/nodeclass-hash"
-	NodeClass          = Group + "/ocinodeclass"
-	OciGpuShape        = Group + "/gpu-shape"
-	OciBmShape         = Group + "/baremetal-shape"
-	OciDenseIoShape    = Group + "/denseio-shape"
-	OciInstanceShape   = Group + "/instance-shape"
-	OciFlexShape       = Group + "/flex-shape"
-	OciFaultDomain     = Group + "/fault-domain"
-	ReservationIDLabel = Group + "/capacity-reservation-id"
+	Group                = "oci.oraclecloud.com"
+	NodeClassHash        = Group + "/nodeclass-hash"
+	NodeClassHashVersion = Group + "/nodeclass-hash-version"
+	NodeClass            = Group + "/ocinodeclass"
+	OciGpuShape          = Group + "/gpu-shape"
+	OciBmShape           = Group + "/baremetal-shape"
+	OciDenseIoShape      = Group + "/denseio-shape"
+	OciInstanceShape     = Group + "/instance-shape"
+	OciFlexShape         = Group + "/flex-shape"
+	OciFaultDomain       = Group + "/fault-domain"
+	ReservationIDLabel   = Group + "/capacity-reservation-id"
 )
+
+// We need to bump the OCINodeClassHashVersion when we make an update to the OCINodeClass CRD under these conditions:
+// 1. A field changes its default value for an existing field that is already hashed
+// 2. A field is added to the hash calculation with an already-set value
+// 3. A field is removed from the hash calculations
+const OCINodeClassHashVersion = "v1"

--- a/pkg/cloudprovider/cloud_provider.go
+++ b/pkg/cloudprovider/cloud_provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oracle/karpenter-provider-oci/pkg/oci"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/capacityreservation"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/npn"
+	"github.com/oracle/karpenter-provider-oci/pkg/utils"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/awslabs/operatorpkg/status"
@@ -236,7 +237,14 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *corev1.NodeClaim)
 		lg.Info("Skipping NPN Object creation")
 	}
 
-	return createNodeClaimFromInstanceAndInstanceType(inst.Instance, selectedInstanceType), nil
+	nodeClaim = createNodeClaimFromInstanceAndInstanceType(inst.Instance, selectedInstanceType)
+	if nodeClaim.Annotations == nil {
+		nodeClaim.Annotations = make(map[string]string)
+	}
+
+	nodeClaim.Annotations[ociv1beta1.NodeClassHash] = utils.HashNodeClassSpec(nodeClass)
+	nodeClaim.Annotations[ociv1beta1.NodeClassHashVersion] = ociv1beta1.OCINodeClassHashVersion
+	return nodeClaim, nil
 }
 
 func (c *CloudProvider) createAndApplyNpnObject(ctx context.Context, instance *instance.InstanceInfo,
@@ -659,6 +667,13 @@ func (c *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *corev1.NodeCla
 		}
 
 		desiredInstanceState.CapacityReservationId = &capRes.Ocid
+	}
+
+	// ------ 0. NodeClass static field hash not matching NodeClaim hash or hash version are not matching --------
+	staticFieldDriftReason := AreStaticFieldsDrifted(ctx, nodeClaim, nodeClass)
+	if staticFieldDriftReason != "" {
+		log.Info("static fields drift detected", "driftReason", staticFieldDriftReason)
+		return staticFieldDriftReason, nil
 	}
 
 	// ---- 1. INSTANCE DRIFT (CACHED, then REAL) ----

--- a/pkg/cloudprovider/cloud_provider_test.go
+++ b/pkg/cloudprovider/cloud_provider_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/network"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/npn"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/placement"
+	"github.com/oracle/karpenter-provider-oci/pkg/utils"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	ocicore "github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/samber/lo"
@@ -120,7 +121,8 @@ var _ = Describe("CloudProvider Tests", func() {
 			crProvider, bsProvider, npnProvider, nil, fakes.NewDummyChannel()))
 	})
 
-	It("should create nodeclaim successfully", func() {
+	It("should create nodeclaim with nodeclass hash", func() {
+
 		nodeClassPtr := &ociTestNodeClass
 		ExpectApplied(ctx, k8sClient, nodeClassPtr)
 		ExpectObjectReconciled(ctx, k8sClient, ociNodeClassController, nodeClassPtr)
@@ -143,9 +145,10 @@ var _ = Describe("CloudProvider Tests", func() {
 			},
 		}
 		resultNodeClaim, err := cloudProvider.Create(ctx, nodeClaimPtr)
-		ExpectExists(ctx, k8sClient, nodeClassPtr)
+		nodeClassPtr = ExpectExists(ctx, k8sClient, nodeClassPtr)
+
 		Expect(err).ToNot(HaveOccurred())
-		Expect(resultNodeClaim).ToNot(BeNil())
+		Expect(resultNodeClaim.Annotations[v1beta1.NodeClassHash]).To(Equal(utils.HashNodeClassSpec(nodeClassPtr)))
 	})
 
 	It("should priority spot shape first according to price", func() {

--- a/pkg/cloudprovider/drift.go
+++ b/pkg/cloudprovider/drift.go
@@ -15,9 +15,12 @@ import (
 	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/instance"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/instancetype"
-	ocicore "github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+	corev1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
 const (
@@ -254,4 +257,35 @@ func isLaunchOptionMismatch(desired *ocicore.LaunchOptions, actual *ocicore.Laun
 
 	// IsPvEncryptionInTransitEnabled is deprecated so not checking it here
 	return false
+}
+
+func AreStaticFieldsDrifted(ctx context.Context, nodeClaim *corev1.NodeClaim,
+	nodeClass *v1beta1.OCINodeClass) cloudprovider.DriftReason {
+
+	nodeClassHash, foundNodeClassHash := nodeClass.Annotations[v1beta1.NodeClassHash]
+	nodeClassHashVersion, foundNodeClassHashVersion := nodeClass.Annotations[v1beta1.NodeClassHashVersion]
+	nodeClaimHash, foundNodeClaimHash := nodeClaim.Annotations[v1beta1.NodeClassHash]
+	nodeClaimHashVersion, foundNodeClaimHashVersion := nodeClaim.Annotations[v1beta1.NodeClassHashVersion]
+
+	if !foundNodeClassHash || !foundNodeClaimHash || !foundNodeClassHashVersion || !foundNodeClaimHashVersion {
+		return ""
+	}
+	// validate that the hash version for the OCINodeClass is the same as the NodeClaim before evaluating for static drift
+	if nodeClassHashVersion != nodeClaimHashVersion {
+		log.FromContext(ctx).Info("NodeClassVersionDrift",
+			"nodeClaim", nodeClaim.Name,
+			"nodeClassHashVersion", nodeClassHashVersion,
+			"nodeClaimHashVersion", nodeClaimHashVersion)
+		return "NodeClassVersionDrift"
+	}
+
+	if nodeClassHash != nodeClaimHash {
+		log.FromContext(ctx).Info("NodeClassStaticFieldDrift",
+			"nodeClaim", nodeClaim.Name,
+			"nodeClassHash", nodeClassHash,
+			"nodeClaimHash", nodeClaimHash)
+		return "NodeClassStaticFieldDrift"
+	}
+
+	return ""
 }

--- a/pkg/cloudprovider/drift_test.go
+++ b/pkg/cloudprovider/drift_test.go
@@ -17,12 +17,16 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
 	"github.com/oracle/karpenter-provider-oci/pkg/fakes"
-	ocicore "github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+	corev1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
 var _ = Describe("Drift Tests", func() {
+
 	It("should handle second vnic drift properly", func() {
 		testCases := []struct {
 			VnicAttachments     []*ocicore.VnicAttachment
@@ -353,6 +357,56 @@ var _ = Describe("Drift Tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result).To(Equal(cloudprovider.DriftReason("")))
 	})
+
+	It("should detect static field drift correctly with AreStaticFieldsDrifted", func() {
+		var (
+			hashValue1 = "hashval1"
+			hashValue2 = "hashval2"
+			hashVer1   = "v1"
+			hashVer2   = "v2"
+		)
+
+		ctx := context.TODO()
+
+		// Case: All hashes and versions match -> no drift
+		nodeClass := makeNodeClass(hashValue1, hashVer1, true, true)
+		nodeClaim := makeNodeClaim(hashValue1, hashVer1, true, true)
+		Expect(AreStaticFieldsDrifted(ctx, nodeClaim, nodeClass)).To(Equal(cloudprovider.DriftReason("")))
+
+		// Case: Hash versions differ -> version drift
+		nodeClass = makeNodeClass(hashValue1, hashVer2, true, true)
+		nodeClaim = makeNodeClaim(hashValue1, hashVer1, true, true)
+		Expect(AreStaticFieldsDrifted(ctx, nodeClaim, nodeClass)).
+			To(Equal(cloudprovider.DriftReason("NodeClassVersionDrift")))
+
+		// Case: Hashes differ but versions same -> static field drift
+		nodeClass = makeNodeClass(hashValue1, hashVer1, true, true)
+		nodeClaim = makeNodeClaim(hashValue2, hashVer1, true, true)
+		Expect(AreStaticFieldsDrifted(ctx, nodeClaim, nodeClass)).
+			To(Equal(cloudprovider.DriftReason("NodeClassStaticFieldDrift")))
+
+		nodeClass = makeNodeClass(hashValue2, hashVer2, true, true)
+		nodeClaim = makeNodeClaim(hashValue1, hashVer2, true, true)
+		Expect(AreStaticFieldsDrifted(ctx, nodeClaim, nodeClass)).
+			To(Equal(cloudprovider.DriftReason("NodeClassStaticFieldDrift")))
+
+		// Case: Any annotation missing -> no drift (empty string)
+		nodeClass = makeNodeClass(hashValue1, hashVer1, false, true) // class missing hash
+		nodeClaim = makeNodeClaim(hashValue1, hashVer1, true, true)
+		Expect(AreStaticFieldsDrifted(ctx, nodeClaim, nodeClass)).To(Equal(cloudprovider.DriftReason("")))
+
+		nodeClass = makeNodeClass(hashValue1, hashVer1, true, false) // class missing version
+		nodeClaim = makeNodeClaim(hashValue1, hashVer1, true, true)
+		Expect(AreStaticFieldsDrifted(ctx, nodeClaim, nodeClass)).To(Equal(cloudprovider.DriftReason("")))
+
+		nodeClass = makeNodeClass(hashValue1, hashVer1, true, true)
+		nodeClaim = makeNodeClaim(hashValue1, hashVer1, false, true) // claim missing hash
+		Expect(AreStaticFieldsDrifted(ctx, nodeClaim, nodeClass)).To(Equal(cloudprovider.DriftReason("")))
+
+		nodeClass = makeNodeClass(hashValue1, hashVer1, true, true)
+		nodeClaim = makeNodeClaim(hashValue1, hashVer1, true, false) // claim missing version
+		Expect(AreStaticFieldsDrifted(ctx, nodeClaim, nodeClass)).To(Equal(cloudprovider.DriftReason("")))
+	})
 })
 
 func createVnicAttachment(vnicOcid string, subnetId string) *ocicore.VnicAttachment {
@@ -381,4 +435,32 @@ var defaultLaunchOption = ocicore.LaunchOptions{
 	NetworkType:                     ocicore.LaunchOptionsNetworkTypeParavirtualized,
 	RemoteDataVolumeType:            ocicore.LaunchOptionsRemoteDataVolumeTypeParavirtualized,
 	IsConsistentVolumeNamingEnabled: lo.ToPtr(true),
+}
+
+func makeNodeClass(hash, hashVer string, addHash, addVer bool) *v1beta1.OCINodeClass {
+	nc := fakes.CreateBasicOciNodeClass()
+	nc.Annotations = map[string]string{}
+	if addHash {
+		nc.Annotations[v1beta1.NodeClassHash] = hash
+	}
+	if addVer {
+		nc.Annotations[v1beta1.NodeClassHashVersion] = hashVer
+	}
+	return &nc
+}
+
+func makeNodeClaim(hash, hashVer string, addHash, addVer bool) *corev1.NodeClaim {
+	nc := &corev1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+	nc.Name = "test-nodeclaim"
+	if addHash {
+		nc.Annotations[v1beta1.NodeClassHash] = hash
+	}
+	if addVer {
+		nc.Annotations[v1beta1.NodeClassHashVersion] = hashVer
+	}
+	return nc
 }

--- a/pkg/controllers/nodeclasses/hash.go
+++ b/pkg/controllers/nodeclasses/hash.go
@@ -11,6 +11,7 @@ import (
 	"context"
 
 	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
+	"github.com/oracle/karpenter-provider-oci/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -18,25 +19,17 @@ type Hash struct {
 }
 
 func (h *Hash) Reconcile(ctx context.Context, nodeClass *v1beta1.OCINodeClass) (reconcile.Result, error) {
-	// if nodeClass.StatusConditions().Root().IsTrue() {
-	// var infs []interface{}
-	// infs = append(infs, nodeClass.Spec)
-	// infs = append(infs, nodeClass.Status.Volume)
-	// infs = append(infs, nodeClass.Status.Network)
-	//
-	// hash, err := utils.HashForMultiObjects(infs)
-	// if err != nil {
-	//	return reconcile.Result{
-	//		RequeueAfter: 5 * time.Minute,
-	//	}, nil
-	// }
-	//
-	// if nodeClass.Annotations == nil {
-	//	nodeClass.Annotations = make(map[string]string)
-	// }
-	//
-	// nodeClass.Annotations[v1beta1.NodeClassHash] = hash
-	// }
+	if nodeClass.StatusConditions().Root().IsTrue() {
+		// TODO may need to update nodeClaim hash here if NodeClassHashVersion is changed
+		hash := utils.HashNodeClassSpec(nodeClass)
+
+		if nodeClass.Annotations == nil {
+			nodeClass.Annotations = make(map[string]string)
+		}
+
+		nodeClass.Annotations[v1beta1.NodeClassHash] = hash
+		nodeClass.Annotations[v1beta1.NodeClassHashVersion] = v1beta1.OCINodeClassHashVersion
+	}
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/controllers/nodeclasses/hash_test.go
+++ b/pkg/controllers/nodeclasses/hash_test.go
@@ -74,6 +74,9 @@ var _ = Describe("Hash Reconciler", func() {
 		nodeClassPtr = ExpectExists(ctx, k8sClient, nodeClassPtr)
 
 		Expect(nodeClassPtr).NotTo(BeNil())
+		Expect(nodeClassPtr.Annotations).NotTo(BeNil())
+		Expect(nodeClassPtr.Annotations[v1beta1.NodeClassHash]).NotTo(BeNil())
+		Expect(nodeClassPtr.Annotations[v1beta1.NodeClassHashVersion]).To(Equal(v1beta1.OCINodeClassHashVersion))
 	})
 
 	It("should not create hash if nodeClass not ready", func() {

--- a/pkg/controllers/nodeclasses/ocinodeclass_controller.go
+++ b/pkg/controllers/nodeclasses/ocinodeclass_controller.go
@@ -141,6 +141,23 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1beta1.OCINodeCl
 	log.Info(fmt.Sprintf("post reconcile: %v", nodeClass))
 
 	if !equality.Semantic.DeepEqual(stored, nodeClass) {
+		newHash, foundNewHash := nodeClass.Annotations[v1beta1.NodeClassHash]
+		existingHash, foundExistingHash := stored.Annotations[v1beta1.NodeClassHash]
+
+		if (!foundExistingHash && foundNewHash) || (foundExistingHash && foundNewHash && newHash != existingHash) {
+			annotationPatchOnly := nodeClass.DeepCopy()
+			if err := c.Client.Patch(ctx, annotationPatchOnly,
+				client.MergeFromWithOptions(stored, client.MergeFromWithOptimisticLock{})); err != nil {
+				if errors.IsConflict(err) {
+					return reconcile.Result{Requeue: true}, nil
+				}
+				errs = multierr.Append(errs, client.IgnoreNotFound(err))
+			}
+
+			nodeClass.ResourceVersion = annotationPatchOnly.ResourceVersion
+			stored = annotationPatchOnly
+		}
+
 		// We use client.MergeFromWithOptimisticLock because patching a list with a JSON merge patch
 		// can cause races due to the fact that it fully replaces the list on a change
 		// Here, we are updating the status condition list

--- a/pkg/utils/hash.go
+++ b/pkg/utils/hash.go
@@ -11,6 +11,10 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+
+	"github.com/mitchellh/hashstructure/v2"
+	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
+	"github.com/samber/lo"
 )
 
 func HashFor(any interface{}) (string, error) {
@@ -48,4 +52,119 @@ func Digest(b []byte) string {
 
 	// Convert the hash to a hex string
 	return fmt.Sprintf("%x", hash)
+}
+
+func HashNodeClassSpec(nodeClass *v1beta1.OCINodeClass) string {
+	var infs []interface{}
+
+	originalSpec := nodeClass.Spec.DeepCopy()
+	ncSpecToSerialize := createStaticFieldsClone(originalSpec)
+
+	infs = append(infs, ncSpecToSerialize)
+
+	return KarpenterHash(infs)
+}
+
+func createStaticFieldsClone(originalSpec *v1beta1.OCINodeClassSpec) *v1beta1.OCINodeClassSpec {
+	ncSpecToSerialize := newEmptyOCINodeClassSpec()
+
+	// Set ShapeConfigs static fields
+	for _, originalShapeConfig := range originalSpec.ShapeConfigs {
+		newShapeConfig := new(v1beta1.ShapeConfig)
+		newShapeConfig.BaselineOcpuUtilization = originalShapeConfig.BaselineOcpuUtilization
+		newShapeConfig.Ocpus = originalShapeConfig.Ocpus
+		newShapeConfig.MemoryInGbs = originalShapeConfig.MemoryInGbs
+		ncSpecToSerialize.ShapeConfigs = append(ncSpecToSerialize.ShapeConfigs, newShapeConfig)
+	}
+
+	// Only set network static fields, dynamic fields is drift checked by IsInstanceNetworkDrifted method
+	ncSpecToSerialize.NetworkConfig.PrimaryVnicConfig =
+		copySimpleVnicConfigStaticFields(originalSpec.NetworkConfig.PrimaryVnicConfig)
+	for _, originalSecondaryVnicConfig := range originalSpec.NetworkConfig.SecondaryVnicConfigs {
+		ncSpecToSerialize.NetworkConfig.SecondaryVnicConfigs = append(ncSpecToSerialize.NetworkConfig.SecondaryVnicConfigs,
+			copySecondaryVnicConfigStaticFields(originalSecondaryVnicConfig))
+	}
+
+	// Set KubeletConfig static fields
+	if originalSpec.KubeletConfig != nil {
+		ncSpecToSerialize.KubeletConfig = new(v1beta1.KubeletConfiguration)
+		ncSpecToSerialize.KubeletConfig.ClusterDNS = originalSpec.KubeletConfig.ClusterDNS
+		ncSpecToSerialize.KubeletConfig.ExtraArgs = originalSpec.KubeletConfig.ExtraArgs
+		ncSpecToSerialize.KubeletConfig.NodeLabels = originalSpec.KubeletConfig.NodeLabels
+		ncSpecToSerialize.KubeletConfig.MaxPods = originalSpec.KubeletConfig.MaxPods
+		ncSpecToSerialize.KubeletConfig.PodsPerCore = originalSpec.KubeletConfig.PodsPerCore
+		ncSpecToSerialize.KubeletConfig.SystemReserved = originalSpec.KubeletConfig.SystemReserved
+		ncSpecToSerialize.KubeletConfig.KubeReserved = originalSpec.KubeletConfig.KubeReserved
+		ncSpecToSerialize.KubeletConfig.EvictionHard = originalSpec.KubeletConfig.EvictionHard
+		ncSpecToSerialize.KubeletConfig.EvictionSoft = originalSpec.KubeletConfig.EvictionSoft
+		ncSpecToSerialize.KubeletConfig.EvictionSoftGracePeriod = originalSpec.KubeletConfig.EvictionSoftGracePeriod
+		ncSpecToSerialize.KubeletConfig.EvictionMaxPodGracePeriod = originalSpec.KubeletConfig.EvictionMaxPodGracePeriod
+		ncSpecToSerialize.KubeletConfig.ImageGCHighThresholdPercent = originalSpec.KubeletConfig.ImageGCHighThresholdPercent
+		ncSpecToSerialize.KubeletConfig.ImageGCLowThresholdPercent = originalSpec.KubeletConfig.ImageGCLowThresholdPercent
+	}
+
+	ncSpecToSerialize.NodeCompartmentId = originalSpec.NodeCompartmentId
+	ncSpecToSerialize.Metadata = originalSpec.Metadata
+	ncSpecToSerialize.FreeformTags = originalSpec.FreeformTags
+	ncSpecToSerialize.DefinedTags = originalSpec.DefinedTags
+	ncSpecToSerialize.PreBootstrapInitScript = originalSpec.PreBootstrapInitScript
+	ncSpecToSerialize.PostBootstrapInitScript = originalSpec.PostBootstrapInitScript
+	ncSpecToSerialize.SshAuthorizedKeys = originalSpec.SshAuthorizedKeys
+
+	// Below is covered by IsInstanceDrifted
+	// ncSpecToSerialize.ClusterPlacementGroupConfigs
+	// ncSpecToSerialize.CapacityReservationConfigs
+	// ncSpecToSerialize.ComputeClusterConfig
+	// ncSpecToSerialize.LaunchOptions
+
+	// Below is covered by IsInstanceBootVolumeDrifted
+	// ncSpecToSerialize.VolumeConfig
+
+	return ncSpecToSerialize
+}
+
+func newEmptyOCINodeClassSpec() *v1beta1.OCINodeClassSpec {
+	ncSpecToSerialize := new(v1beta1.OCINodeClassSpec)
+	ncSpecToSerialize.ShapeConfigs = make([]*v1beta1.ShapeConfig, 0)
+	ncSpecToSerialize.NetworkConfig = &v1beta1.NetworkConfig{
+		PrimaryVnicConfig:    &v1beta1.SimpleVnicConfig{},
+		SecondaryVnicConfigs: make([]*v1beta1.SecondaryVnicConfig, 0),
+	}
+	return ncSpecToSerialize
+}
+
+func copySimpleVnicConfigStaticFields(originalVnicConfig *v1beta1.SimpleVnicConfig) *v1beta1.SimpleVnicConfig {
+	newVnicConfig := &v1beta1.SimpleVnicConfig{}
+	newVnicConfig.AssignIpV6Ip = originalVnicConfig.AssignIpV6Ip
+	newVnicConfig.AssignPublicIp = originalVnicConfig.AssignPublicIp
+	newVnicConfig.Ipv6AddressIpv6SubnetCidrPairDetails = originalVnicConfig.Ipv6AddressIpv6SubnetCidrPairDetails
+	newVnicConfig.SkipSourceDestCheck = originalVnicConfig.SkipSourceDestCheck
+	newVnicConfig.SecurityAttributes = originalVnicConfig.SecurityAttributes
+
+	return newVnicConfig
+}
+
+func copySecondaryVnicConfigStaticFields(
+	originalSecondaryVnicConfig *v1beta1.SecondaryVnicConfig) *v1beta1.SecondaryVnicConfig {
+	newSecondaryVnicConfig := &v1beta1.SecondaryVnicConfig{
+		SimpleVnicConfig:    *copySimpleVnicConfigStaticFields(&originalSecondaryVnicConfig.SimpleVnicConfig),
+		ApplicationResource: originalSecondaryVnicConfig.ApplicationResource,
+		IpCount:             originalSecondaryVnicConfig.IpCount,
+		NicIndex:            originalSecondaryVnicConfig.NicIndex,
+	}
+
+	return newSecondaryVnicConfig
+}
+
+// KarpenterHash This method is using the same hash algorithm from Karpenter code
+func KarpenterHash(data []interface{}) string {
+	hash := lo.Must(hashstructure.Hash(data,
+		hashstructure.FormatV2,
+		&hashstructure.HashOptions{
+			SlicesAsSets:    true,
+			IgnoreZeroValue: true,
+			ZeroNil:         true,
+		}))
+
+	return fmt.Sprint(hash)
 }

--- a/pkg/utils/hash_test.go
+++ b/pkg/utils/hash_test.go
@@ -8,8 +8,11 @@
 package utils
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,4 +84,72 @@ func TestHashForMarshalError(t *testing.T) {
 	fn := func() {}
 	_, err = HashFor(fn)
 	require.Error(t, err)
+}
+
+func TestHashNodeClassSpec_StaticFieldsCloning(t *testing.T) {
+	// Prepare a nodeClass spec with both static and non-static fields
+	staticValue := "STATIC"
+	dynamicValue := "DYNAMIC"
+	dynamicValue2 := "DYNAMIC_CHANGED"
+	assignIPv6 := true
+	assignPub := true
+	ipv6Detail := &v1beta1.Ipv6AddressIpv6SubnetCidrPairDetails{SubnetCidr: "subnet-cidr"}
+	ipv6List := []*v1beta1.Ipv6AddressIpv6SubnetCidrPairDetails{ipv6Detail}
+	skipSrcDest := true
+	securityAttrs := map[string]map[string]string{"foo": {"bar": "baz"}}
+
+	primaryVnic := &v1beta1.SimpleVnicConfig{
+		AssignIpV6Ip:                         &assignIPv6,
+		AssignPublicIp:                       &assignPub,
+		Ipv6AddressIpv6SubnetCidrPairDetails: ipv6List,
+		SkipSourceDestCheck:                  &skipSrcDest,
+		SecurityAttributes:                   securityAttrs,
+		VnicDisplayName:                      &dynamicValue, // dynamic
+	}
+	secondaryVnic := &v1beta1.SecondaryVnicConfig{
+		SimpleVnicConfig:    *primaryVnic,
+		ApplicationResource: &staticValue,
+		IpCount:             lo.ToPtr(4),
+		NicIndex:            lo.ToPtr(2),
+	}
+	staticCompartmentID := staticValue
+	nodeClass := &v1beta1.OCINodeClass{
+		Spec: v1beta1.OCINodeClassSpec{
+			ShapeConfigs: []*v1beta1.ShapeConfig{
+				{
+					BaselineOcpuUtilization: nil,
+					Ocpus:                   lo.ToPtr(float32(2)),
+					MemoryInGbs:             lo.ToPtr(float32(1)),
+				},
+			},
+			NodeCompartmentId: &staticCompartmentID,
+			NetworkConfig: &v1beta1.NetworkConfig{
+				PrimaryVnicConfig:    primaryVnic,
+				SecondaryVnicConfigs: []*v1beta1.SecondaryVnicConfig{secondaryVnic},
+			},
+			Metadata:                map[string]string{"foo": "bar"},
+			FreeformTags:            map[string]string{"myTag": "myVal"},
+			DefinedTags:             map[string]map[string]string{"myNs": {"key": "val"}},
+			PreBootstrapInitScript:  &staticValue,
+			PostBootstrapInitScript: &staticValue,
+			SshAuthorizedKeys:       []string{"ssh-rsa AAA..."},
+		},
+	}
+
+	// Hash with all fields set
+	initialHash := HashNodeClassSpec(nodeClass)
+
+	// Mutate dynamic fields, verify hash does NOT change
+	nodeClass.Spec.NetworkConfig.PrimaryVnicConfig.VnicDisplayName = &dynamicValue2
+
+	hashAfterDynamicChanges := HashNodeClassSpec(nodeClass)
+	require.Equal(t, initialHash, hashAfterDynamicChanges,
+		fmt.Sprintf("Hash should not change when non-static (dynamic) fields changed; got changed from '%v' to '%v'",
+			initialHash, hashAfterDynamicChanges))
+
+	// Mutate a static field, verify hash DOES change
+	nodeClass.Spec.NodeCompartmentId = lo.ToPtr("DIFFERENT")
+	hashAfterStaticChange := HashNodeClassSpec(nodeClass)
+	require.NotEqual(t, initialHash, hashAfterStaticChange,
+		fmt.Sprintf("Hash must change when static field changes, but did not (still '%v')", initialHash))
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # Refactoring on drift logic to cover "all" fields

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] NodeClassHash added to NodeClass and its NodeClaims
<img width="893" height="426" alt="download" src="https://github.com/user-attachments/assets/97dd7327-99d5-4ec7-ac84-47ec4436df73" />
<img width="968" height="569" alt="download-2" src="https://github.com/user-attachments/assets/f6998ea7-17cb-4650-a50a-d7de47ce447d" />

- [X] Drift is detected after static fields are changes, and recreating NodeClaims
<img width="1150" height="385" alt="download-3" src="https://github.com/user-attachments/assets/a768d373-ecb3-4ffb-b31e-0ccaf0520475" />
<img width="1020" height="521" alt="download-4" src="https://github.com/user-attachments/assets/5a42eba8-ff24-46ba-b38a-0d3a6e54e4a3" />

- [X] No Drift is detected if there is no change and NodeClaims will not be recreated
<img width="807" height="58" alt="download-5" src="https://github.com/user-attachments/assets/c2c26f8b-0608-4b2f-b7c0-b4c45a6cd565" />

- Kubernetes version: 1.34.2
- OKE version: 1.34.2
- Karpenter Provider OCI version: 
- Installation method (`helm`, manifests, local run): local run

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
