### PR TITLE
fix: populate flat NPN fields for OKE NPN controller compatibility

### DIFF
--- a/pkg/providers/npn/npn_test.go
+++ b/pkg/providers/npn/npn_test.go
@@ -200,6 +200,22 @@ func TestCreateSecondaryVnicsNpnCustomObjectValidInput(t *testing.T) {
 		} else {
 			assert.Equal(t, int64(testMaxPods), result.Spec.MaxPodCount)
 
+			// Verify flat fields are populated for OKE NPN controller compatibility
+			assert.NotEmpty(t, result.Spec.PodSubnetIDs, "podSubnetIds should be populated")
+			assert.NotEmpty(t, result.Spec.IpFamilies, "ipFamilies should be populated")
+			for _, tc := range testCases {
+				assert.Contains(t, result.Spec.PodSubnetIDs, tc.testSubnetId)
+			}
+			expectedIpFamilies := lo.Map(ipFamilyTc.ipFamilies, func(f network.IpFamily, _ int) string {
+				return string(f)
+			})
+			assert.Equal(t, expectedIpFamilies, result.Spec.IpFamilies)
+			// testCases[2] has nsgIds ["nsg1", "nsg2", "nsg3"]
+			assert.NotEmpty(t, result.Spec.NetworkSecurityGroupIDs, "networkSecurityGroupIds should be populated")
+			for _, nsgId := range testCases[2].nsgIds {
+				assert.Contains(t, result.Spec.NetworkSecurityGroupIDs, nsgId)
+			}
+
 			for index, resultSecondaryVnic := range result.Spec.SecondaryVnics {
 				expectedValues := testCases[index]
 
@@ -436,5 +452,75 @@ func TestMaxPodSetting(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expect, result.Spec.MaxPodCount)
+
+		// Verify flat fields are populated
+		assert.Contains(t, result.Spec.PodSubnetIDs, testSubnetId)
+		assert.Equal(t, []string{"IPv4"}, result.Spec.IpFamilies)
 	}
+}
+
+func TestFlatFieldsDeduplication(t *testing.T) {
+	teardownTest := setupTest(t)
+	defer teardownTest(t)
+
+	// Two secondary VNICs sharing the same subnet but different NSGs
+	sharedSubnetId := "ocid1.subnet.shared"
+	nsg1 := "ocid1.nsg.1"
+	nsg2 := "ocid1.nsg.2"
+
+	secondaryVnicConfigs := []*ociv1beta1.SecondaryVnicConfig{
+		{
+			SimpleVnicConfig: ociv1beta1.SimpleVnicConfig{
+				SubnetAndNsgConfig: &ociv1beta1.SubnetAndNsgConfig{
+					SubnetConfig: &ociv1beta1.SubnetConfig{SubnetId: &sharedSubnetId},
+				},
+			},
+			IpCount: lo.ToPtr(16),
+		},
+		{
+			SimpleVnicConfig: ociv1beta1.SimpleVnicConfig{
+				SubnetAndNsgConfig: &ociv1beta1.SubnetAndNsgConfig{
+					SubnetConfig: &ociv1beta1.SubnetConfig{SubnetId: &sharedSubnetId},
+				},
+			},
+			IpCount: lo.ToPtr(16),
+		},
+	}
+
+	otherVnicSubnets := []*network.SubnetAndNsgs{
+		{
+			Subnet:                &ocicore.Subnet{Id: &sharedSubnetId},
+			NetworkSecurityGroups: NsgIdsToNetworkSecurityGroupObjects([]string{nsg1, nsg2}),
+		},
+		{
+			Subnet:                &ocicore.Subnet{Id: &sharedSubnetId},
+			NetworkSecurityGroups: NsgIdsToNetworkSecurityGroupObjects([]string{nsg1}),
+		},
+	}
+
+	// Test with dual-stack IP families
+	provider.ipFamilies = ipV6DualStack
+
+	result, err := provider.createNpnCustomObject(context.TODO(), "testName", "testInstanceId",
+		&ociv1beta1.NetworkConfig{SecondaryVnicConfigs: secondaryVnicConfigs},
+		&network.NetworkResolveResult{OtherVnicSubnets: otherVnicSubnets},
+		nil)
+
+	assert.NoError(t, err)
+
+	// Subnet IDs should be deduplicated
+	assert.Equal(t, []string{sharedSubnetId}, result.Spec.PodSubnetIDs,
+		"duplicate subnet IDs should be deduplicated")
+
+	// NSG IDs should be deduplicated across VNICs
+	assert.Len(t, result.Spec.NetworkSecurityGroupIDs, 2,
+		"NSG IDs should be deduplicated across VNICs")
+	assert.Contains(t, result.Spec.NetworkSecurityGroupIDs, nsg1)
+	assert.Contains(t, result.Spec.NetworkSecurityGroupIDs, nsg2)
+
+	// IP families should reflect provider config
+	assert.Equal(t, []string{"IPv4", "IPv6"}, result.Spec.IpFamilies)
+
+	// Secondary VNICs should still be populated (nested format preserved)
+	assert.Len(t, result.Spec.SecondaryVnics, 2)
 }

--- a/pkg/providers/npn/provider.go
+++ b/pkg/providers/npn/provider.go
@@ -174,14 +174,37 @@ func (p *DefaultProvider) constructSecondaryVnicsNpnSpec(ctx context.Context,
 		}
 	}
 
+	// Populate flat fields for OKE NPN controller compatibility.
+	// The OKE NPN controller requires podSubnetIds, networkSecurityGroupIds,
+	// and ipFamilies at the top level to complete reconciliation.
+	podSubnetIds := lo.Uniq(lo.FilterMap(secondaryVnicsSpec, func(sv npnv1beta1.SecondaryVnic, _ int) (string, bool) {
+		if sv.CreateVnicDetails.SubnetId != nil {
+			return *sv.CreateVnicDetails.SubnetId, true
+		}
+		return "", false
+	}))
+
+	var allNsgIds []string
+	for _, sv := range secondaryVnicsSpec {
+		allNsgIds = append(allNsgIds, sv.CreateVnicDetails.NsgIds...)
+	}
+	allNsgIds = lo.Uniq(allNsgIds)
+
+	ipFamilyStrings := lo.Map(p.ipFamilies, func(f network.IpFamily, _ int) string {
+		return string(f)
+	})
+
 	log.FromContext(ctx).Info("Creating Secondary Npn Spec values",
 		"MaxPodCount", maxPods,
 		"SecondaryVnics", secondaryVnicsSpec)
 
 	npnSpec := &npnv1beta1.NativePodNetworkSpec{
-		ID:             instanceId,
-		MaxPodCount:    maxPods,
-		SecondaryVnics: secondaryVnicsSpec,
+		ID:                      instanceId,
+		MaxPodCount:             maxPods,
+		SecondaryVnics:          secondaryVnicsSpec,
+		PodSubnetIDs:            podSubnetIds,
+		NetworkSecurityGroupIDs: allNsgIds,
+		IpFamilies:              ipFamilyStrings,
 	}
 	return npnSpec, nil
 }


### PR DESCRIPTION
## Summary

Populate `podSubnetIds`, `networkSecurityGroupIds`, and `ipFamilies` in the `NativePodNetworkSpec` alongside the existing `secondaryVnics` nested format.

The OKE NPN controller requires these flat fields to complete reconciliation. Without them, the NPN stays at `IN_PROGRESS` indefinitely, blocking secondary VNIC configuration and preventing Karpenter-provisioned nodes from registering with the cluster.

Fixes #5

## Changes

- **`pkg/providers/npn/provider.go`**: After building the `secondaryVnicsSpec` array, extract unique subnet IDs and NSG IDs from the built specs and convert `p.ipFamilies` to `[]string`. Populate `PodSubnetIDs`, `NetworkSecurityGroupIDs`, and `IpFamilies` in the `NativePodNetworkSpec`.

- **`pkg/providers/npn/npn_test.go`**: Added flat field assertions to `TestCreateSecondaryVnicsNpnCustomObjectValidInput` and `TestMaxPodSetting`. Added new `TestFlatFieldsDeduplication` test covering dual-stack IP families, shared subnets, and NSG deduplication across VNICs.

## Root Cause

In `constructSecondaryVnicsNpnSpec()`, the `NativePodNetworkSpec` was constructed with only `ID`, `MaxPodCount`, and `SecondaryVnics`:

```go
npnSpec := &npnv1beta1.NativePodNetworkSpec{
    ID:             instanceId,
    MaxPodCount:    maxPods,
    SecondaryVnics: secondaryVnicsSpec,
}
```

The struct already defines `PodSubnetIDs`, `NetworkSecurityGroupIDs`, and `IpFamilies` fields — they were just never populated. NPN objects created by the OKE control plane for static node pools always include these flat fields, which the NPN controller relies on for reconciliation.

## Testing

- All existing tests pass with new assertions for flat fields
- New `TestFlatFieldsDeduplication` covers:
  - Dual-stack IP families (`["IPv4", "IPv6"]`)
  - Duplicate subnet IDs are deduplicated across VNICs
  - NSG IDs are deduplicated across VNICs
  - Nested `secondaryVnics` format preserved alongside flat fields
- `go test ./pkg/providers/npn/... -v` — all PASS

## Backward Compatibility

This change is purely additive. The `secondaryVnics` nested format is preserved unchanged. Controllers that read either format will work correctly.