### PR TITLE
Append karpenter-provider-oci to the user agent

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -98,6 +98,8 @@ spec:
               value: "{{ .Values.controller.metrics.port }}"
             - name: HEALTH_PROBE_PORT
               value: "{{ .Values.controller.healthProbe.port }}"
+            - name: OCI_SDK_APPEND_USER_AGENT
+              value: "karpenter-provider-oci"
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
# Description

Append karpenter-provider-oci to the user agent.

This helps identify logs of the requests to OCI services being made by Karpenter.