### PR TITLE
Add OCI Rate Limiter for KPO

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -144,6 +144,26 @@ spec:
             - name: APISERVER_ENDPOINT
               value: "{{ . }}"
             {{- end }}
+            {{- if hasKey .Values.settings.rateLimiter "disable" }}
+            - name: DISABLE_RATE_LIMITER
+              value: "{{ .Values.settings.rateLimiter.disable }}"
+            {{- end }}
+            {{- with .Values.settings.rateLimiter.qpsRead }}
+            - name: RATE_LIMIT_QPS_READ
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.settings.rateLimiter.burstRead }}
+            - name: RATE_LIMIT_BURST_READ
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.settings.rateLimiter.qpsWrite }}
+            - name: RATE_LIMIT_QPS_WRITE
+              value: "{{ . }}"
+            {{- end }}
+            {{- with .Values.settings.rateLimiter.burstWrite }}
+            - name: RATE_LIMIT_BURST_WRITE
+              value: "{{ . }}"
+            {{- end }}
             {{- with .Values.settings.flexibleShapeConfigs }}
             - name: FLEXIBLE_SHAPE_CONFIGS
               value: {{ . | toJson | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -244,6 +244,18 @@ settings:
   # -- [required] API server endpoint(privateIP) for worker nodes to communicate with the Kubernetes API server.
   apiserverEndpoint: ""
 
+  rateLimiter:
+    # -- Disable the OCI client-side rate limiter.
+    disable: true
+    # -- Read QPS for the OCI client-side rate limiter. 0 uses the built-in default.
+    qpsRead: 0
+    # -- Read burst for the OCI client-side rate limiter. 0 uses the built-in default.
+    burstRead: 0
+    # -- Write QPS for the OCI client-side rate limiter. 0 uses the built-in default.
+    qpsWrite: 0
+    # -- Write burst for the OCI client-side rate limiter. 0 uses the built-in default.
+    burstWrite: 0
+
   # -- The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one
   # time which usually results in fewer but larger nodes.
   batchMaxDuration: 10s

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -121,7 +121,11 @@ func MeasureCallDuration(apiName string) func() time.Duration {
 
 func CountResponseStatus(apiName string, input interface{}) {
 	if ociResponse, ok := input.(common.OCIResponse); ok {
-		statusCode := ociResponse.HTTPResponse().StatusCode
+		httpResponse := ociResponse.HTTPResponse()
+		if httpResponse == nil {
+			return
+		}
+		statusCode := httpResponse.StatusCode
 
 		ExternalApiCallStatusCounter.Inc(
 			map[string]string{

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -8,6 +8,7 @@
 package metrics
 
 import (
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -15,6 +16,12 @@ import (
 	"github.com/oracle/karpenter-provider-oci/pkg/fakes"
 	"github.com/stretchr/testify/assert"
 )
+
+type nilHTTPResponse struct{}
+
+func (nilHTTPResponse) HTTPResponse() *http.Response {
+	return nil
+}
 
 func TestMeasureCallDuration(t *testing.T) {
 	testCases := []int{5, 10, 12, 21}
@@ -97,6 +104,12 @@ func TestCountResponseStatusTypeNotMatch(t *testing.T) {
 			ApiStatusCodeLabel: strconv.Itoa(200),
 		})
 	assert.False(t, ok)
+}
+
+func TestCountResponseStatusNilHTTPResponse(t *testing.T) {
+	assert.NotPanics(t, func() {
+		CountResponseStatus("testApiNilHTTPResponse", nilHTTPResponse{})
+	})
 }
 
 func TestRecordWorkRequestProcessTime(t *testing.T) {

--- a/pkg/oci/client.go
+++ b/pkg/oci/client.go
@@ -86,25 +86,13 @@ func newComputeClient(config common.ConfigurationProvider) (*ocicore.ComputeClie
 	return &c, nil
 }
 
-func NewKmsClient(config common.ConfigurationProvider, endpoint string) (KmsClient, error) {
+func NewKmsClient(config common.ConfigurationProvider, endpoint string, rateLimiter *RateLimiter) (KmsClient, error) {
 	raw, err := ocikms.NewKmsManagementClientWithConfigurationProvider(config, endpoint)
 	if err != nil {
 		return nil, err
 	}
 	raw.Configuration.RetryPolicy = newRetryPolicy()
-	return &kmsDecoratedClient{inner: &raw}, nil
-}
-
-// kmsDecoratedClient adapts the OCI KMS client to add centralized logging.
-type kmsDecoratedClient struct {
-	inner *ocikms.KmsManagementClient
-}
-
-func (k *kmsDecoratedClient) GetKey(ctx context.Context,
-	req ocikms.GetKeyRequest) (ocikms.GetKeyResponse, error) {
-	return decorate(ctx, "GetKey", req, func() (ocikms.GetKeyResponse, error) {
-		return k.inner.GetKey(ctx, req)
-	})
+	return &kmsDecoratedClient{inner: &raw, limiter: normalizeRateLimiter(rateLimiter)}, nil
 }
 
 // newBlockStorageClient creates a BlockStorageClient with the default retry policy applied
@@ -169,7 +157,7 @@ func newClusterPlacementGroupClient(config common.ConfigurationProvider) (
 }
 
 // NewClient creates Client for all OCI services with centralized logging
-func NewClient(ctx context.Context, config common.ConfigurationProvider) (*Client, error) {
+func NewClient(ctx context.Context, config common.ConfigurationProvider, rateLimiter *RateLimiter) (*Client, error) {
 	compute, err := newComputeClient(config)
 	if err != nil {
 		return nil, err
@@ -200,7 +188,15 @@ func NewClient(ctx context.Context, config common.ConfigurationProvider) (*Clien
 		return nil, err
 	}
 
-	return newClient(compute, blockStorage, virtualNetwork, identity, workRequest, clusterPlacementGroup), nil
+	rl := normalizeRateLimiter(rateLimiter)
+	return newClient(
+		&rateLimitedComputeClient{inner: compute, limiter: rl},
+		&rateLimitedBlockStorageClient{inner: blockStorage, limiter: rl},
+		&rateLimitedVirtualNetworkClient{inner: virtualNetwork, limiter: rl},
+		&rateLimitedIdentityClient{inner: identity, limiter: rl},
+		&rateLimitedWorkRequestClient{inner: workRequest, limiter: rl},
+		&rateLimitedClusterPlacementGroupClient{inner: clusterPlacementGroup, limiter: rl},
+	), nil
 }
 
 // Client wraps OCI clients with centralized logging
@@ -214,9 +210,9 @@ type Client struct {
 }
 
 // newClient creates a new Client wrapper with the provided clients
-func newClient(compute *ocicore.ComputeClient, blockStorage *ocicore.BlockstorageClient,
-	virtualNetwork *ocicore.VirtualNetworkClient, identity *ociidentity.IdentityClient,
-	workRequest *ociwr.WorkRequestClient, clusterPlacementGroup *ocicpg.ClusterPlacementGroupsCPClient) *Client {
+func newClient(compute ComputeClient, blockStorage BlockStorageClient,
+	virtualNetwork VirtualNetworkClient, identity IdentityClient,
+	workRequest WorkRequestClient, clusterPlacementGroup ClusterPlacementGroupClient) *Client {
 	return &Client{
 		Compute:               compute,
 		BlockStorage:          blockStorage,

--- a/pkg/oci/rate_limited_clients.go
+++ b/pkg/oci/rate_limited_clients.go
@@ -1,0 +1,295 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package oci
+
+import (
+	"context"
+
+	ocicpg "github.com/oracle/oci-go-sdk/v65/clusterplacementgroups"
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+	ociidentity "github.com/oracle/oci-go-sdk/v65/identity"
+	ocikms "github.com/oracle/oci-go-sdk/v65/keymanagement"
+	ociwr "github.com/oracle/oci-go-sdk/v65/workrequests"
+	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	readMode  = "read"
+	writeMode = "write"
+)
+
+type rateLimitedComputeClient struct {
+	inner   *ocicore.ComputeClient
+	limiter RateLimiter
+}
+
+type rateLimitedBlockStorageClient struct {
+	inner   *ocicore.BlockstorageClient
+	limiter RateLimiter
+}
+
+type rateLimitedVirtualNetworkClient struct {
+	inner   *ocicore.VirtualNetworkClient
+	limiter RateLimiter
+}
+
+type rateLimitedIdentityClient struct {
+	inner   *ociidentity.IdentityClient
+	limiter RateLimiter
+}
+
+type rateLimitedWorkRequestClient struct {
+	inner   *ociwr.WorkRequestClient
+	limiter RateLimiter
+}
+
+type rateLimitedClusterPlacementGroupClient struct {
+	inner   *ocicpg.ClusterPlacementGroupsCPClient
+	limiter RateLimiter
+}
+
+type kmsDecoratedClient struct {
+	inner   *ocikms.KmsManagementClient
+	limiter RateLimiter
+}
+
+func waitForToken(ctx context.Context, limiter flowcontrol.RateLimiter, operation, mode string) error {
+	if err := limiter.Wait(ctx); err != nil {
+		log.FromContext(ctx).Error(err, "OCI rate limiter wait failed", "operation", operation, "mode", mode)
+		return err
+	}
+	return nil
+}
+
+func callWithReadLimit[T any, R any](ctx context.Context, limiter RateLimiter,
+	operation string, _ R, fn func() (T, error)) (T, error) {
+	var zero T
+	if err := waitForToken(ctx, limiter.Reader, operation, readMode); err != nil {
+		return zero, err
+	}
+	return fn()
+}
+
+func callWithWriteLimit[T any, R any](ctx context.Context, limiter RateLimiter,
+	operation string, _ R, fn func() (T, error)) (T, error) {
+	var zero T
+	if err := waitForToken(ctx, limiter.Writer, operation, writeMode); err != nil {
+		return zero, err
+	}
+	return fn()
+}
+
+func callWithDecoratedReadLimit[T any, R any](ctx context.Context, limiter RateLimiter,
+	operation string, request R, fn func() (T, error)) (T, error) {
+	var zero T
+	if err := waitForToken(ctx, limiter.Reader, operation, readMode); err != nil {
+		return zero, err
+	}
+	return decorate(ctx, operation, request, fn)
+}
+
+func (c *rateLimitedComputeClient) LaunchInstance(ctx context.Context,
+	req ocicore.LaunchInstanceRequest) (ocicore.LaunchInstanceResponse, error) {
+	return callWithWriteLimit(ctx, c.limiter, "LaunchInstance", req, func() (ocicore.LaunchInstanceResponse, error) {
+		return c.inner.LaunchInstance(ctx, req)
+	})
+}
+
+func (c *rateLimitedComputeClient) GetInstance(ctx context.Context,
+	req ocicore.GetInstanceRequest) (ocicore.GetInstanceResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "GetInstance", req, func() (ocicore.GetInstanceResponse, error) {
+		return c.inner.GetInstance(ctx, req)
+	})
+}
+
+func (c *rateLimitedComputeClient) ListInstances(ctx context.Context,
+	req ocicore.ListInstancesRequest) (ocicore.ListInstancesResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "ListInstances", req, func() (ocicore.ListInstancesResponse, error) {
+		return c.inner.ListInstances(ctx, req)
+	})
+}
+
+func (c *rateLimitedComputeClient) ListVnicAttachments(ctx context.Context,
+	req ocicore.ListVnicAttachmentsRequest) (ocicore.ListVnicAttachmentsResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "ListVnicAttachments", req,
+		func() (ocicore.ListVnicAttachmentsResponse, error) {
+			return c.inner.ListVnicAttachments(ctx, req)
+		})
+}
+
+func (c *rateLimitedComputeClient) ListBootVolumeAttachments(ctx context.Context,
+	req ocicore.ListBootVolumeAttachmentsRequest) (ocicore.ListBootVolumeAttachmentsResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "ListBootVolumeAttachments", req,
+		func() (ocicore.ListBootVolumeAttachmentsResponse, error) {
+			return c.inner.ListBootVolumeAttachments(ctx, req)
+		})
+}
+
+func (c *rateLimitedComputeClient) TerminateInstance(ctx context.Context,
+	req ocicore.TerminateInstanceRequest) (ocicore.TerminateInstanceResponse, error) {
+	return callWithWriteLimit(ctx, c.limiter, "TerminateInstance", req, func() (ocicore.TerminateInstanceResponse, error) {
+		return c.inner.TerminateInstance(ctx, req)
+	})
+}
+
+func (c *rateLimitedComputeClient) ListShapes(ctx context.Context,
+	req ocicore.ListShapesRequest) (ocicore.ListShapesResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "ListShapes", req, func() (ocicore.ListShapesResponse, error) {
+		return c.inner.ListShapes(ctx, req)
+	})
+}
+
+func (c *rateLimitedComputeClient) GetComputeCapacityReservation(ctx context.Context,
+	req ocicore.GetComputeCapacityReservationRequest) (ocicore.GetComputeCapacityReservationResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "GetComputeCapacityReservation", req,
+		func() (ocicore.GetComputeCapacityReservationResponse, error) {
+			return c.inner.GetComputeCapacityReservation(ctx, req)
+		})
+}
+
+func (c *rateLimitedComputeClient) ListComputeCapacityReservations(ctx context.Context,
+	req ocicore.ListComputeCapacityReservationsRequest) (ocicore.ListComputeCapacityReservationsResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "ListComputeCapacityReservations", req,
+		func() (ocicore.ListComputeCapacityReservationsResponse, error) {
+			return c.inner.ListComputeCapacityReservations(ctx, req)
+		})
+}
+
+func (c *rateLimitedComputeClient) GetComputeCluster(ctx context.Context,
+	req ocicore.GetComputeClusterRequest) (ocicore.GetComputeClusterResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "GetComputeCluster", req, func() (ocicore.GetComputeClusterResponse, error) {
+		return c.inner.GetComputeCluster(ctx, req)
+	})
+}
+
+func (c *rateLimitedComputeClient) ListComputeClusters(ctx context.Context,
+	req ocicore.ListComputeClustersRequest) (ocicore.ListComputeClustersResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "ListComputeClusters", req, func() (ocicore.ListComputeClustersResponse, error) {
+		return c.inner.ListComputeClusters(ctx, req)
+	})
+}
+
+func (c *rateLimitedComputeClient) GetImage(ctx context.Context,
+	req ocicore.GetImageRequest) (ocicore.GetImageResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "GetImage", req, func() (ocicore.GetImageResponse, error) {
+		return c.inner.GetImage(ctx, req)
+	})
+}
+
+func (c *rateLimitedComputeClient) ListImages(ctx context.Context,
+	req ocicore.ListImagesRequest) (ocicore.ListImagesResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "ListImages", req, func() (ocicore.ListImagesResponse, error) {
+		return c.inner.ListImages(ctx, req)
+	})
+}
+
+func (c *rateLimitedComputeClient) ListImageShapeCompatibilityEntries(ctx context.Context,
+	req ocicore.ListImageShapeCompatibilityEntriesRequest) (ocicore.ListImageShapeCompatibilityEntriesResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "ListImageShapeCompatibilityEntries", req,
+		func() (ocicore.ListImageShapeCompatibilityEntriesResponse, error) {
+			return c.inner.ListImageShapeCompatibilityEntries(ctx, req)
+		})
+}
+
+func (b *rateLimitedBlockStorageClient) GetBootVolume(ctx context.Context,
+	req ocicore.GetBootVolumeRequest) (ocicore.GetBootVolumeResponse, error) {
+	return callWithReadLimit(ctx, b.limiter, "GetBootVolume", req, func() (ocicore.GetBootVolumeResponse, error) {
+		return b.inner.GetBootVolume(ctx, req)
+	})
+}
+
+func (v *rateLimitedVirtualNetworkClient) GetNetworkSecurityGroup(ctx context.Context,
+	req ocicore.GetNetworkSecurityGroupRequest) (ocicore.GetNetworkSecurityGroupResponse, error) {
+	return callWithReadLimit(ctx, v.limiter, "GetNetworkSecurityGroup", req,
+		func() (ocicore.GetNetworkSecurityGroupResponse, error) {
+			return v.inner.GetNetworkSecurityGroup(ctx, req)
+		})
+}
+
+func (v *rateLimitedVirtualNetworkClient) GetSubnet(ctx context.Context,
+	req ocicore.GetSubnetRequest) (ocicore.GetSubnetResponse, error) {
+	return callWithReadLimit(ctx, v.limiter, "GetSubnet", req, func() (ocicore.GetSubnetResponse, error) {
+		return v.inner.GetSubnet(ctx, req)
+	})
+}
+
+func (v *rateLimitedVirtualNetworkClient) ListSubnets(ctx context.Context,
+	req ocicore.ListSubnetsRequest) (ocicore.ListSubnetsResponse, error) {
+	return callWithReadLimit(ctx, v.limiter, "ListSubnets", req, func() (ocicore.ListSubnetsResponse, error) {
+		return v.inner.ListSubnets(ctx, req)
+	})
+}
+
+func (v *rateLimitedVirtualNetworkClient) ListNetworkSecurityGroups(ctx context.Context,
+	req ocicore.ListNetworkSecurityGroupsRequest) (ocicore.ListNetworkSecurityGroupsResponse, error) {
+	return callWithReadLimit(ctx, v.limiter, "ListNetworkSecurityGroups", req,
+		func() (ocicore.ListNetworkSecurityGroupsResponse, error) {
+			return v.inner.ListNetworkSecurityGroups(ctx, req)
+		})
+}
+
+func (v *rateLimitedVirtualNetworkClient) GetVnic(ctx context.Context,
+	req ocicore.GetVnicRequest) (ocicore.GetVnicResponse, error) {
+	return callWithReadLimit(ctx, v.limiter, "GetVnic", req, func() (ocicore.GetVnicResponse, error) {
+		return v.inner.GetVnic(ctx, req)
+	})
+}
+
+func (i *rateLimitedIdentityClient) GetCompartment(ctx context.Context,
+	req ociidentity.GetCompartmentRequest) (ociidentity.GetCompartmentResponse, error) {
+	return callWithReadLimit(ctx, i.limiter, "GetCompartment", req, func() (ociidentity.GetCompartmentResponse, error) {
+		return i.inner.GetCompartment(ctx, req)
+	})
+}
+
+func (i *rateLimitedIdentityClient) ListAvailabilityDomains(ctx context.Context,
+	req ociidentity.ListAvailabilityDomainsRequest) (ociidentity.ListAvailabilityDomainsResponse, error) {
+	return callWithReadLimit(ctx, i.limiter, "ListAvailabilityDomains", req,
+		func() (ociidentity.ListAvailabilityDomainsResponse, error) {
+			return i.inner.ListAvailabilityDomains(ctx, req)
+		})
+}
+
+func (w *rateLimitedWorkRequestClient) GetWorkRequest(ctx context.Context,
+	req ociwr.GetWorkRequestRequest) (ociwr.GetWorkRequestResponse, error) {
+	return callWithReadLimit(ctx, w.limiter, "GetWorkRequest", req, func() (ociwr.GetWorkRequestResponse, error) {
+		return w.inner.GetWorkRequest(ctx, req)
+	})
+}
+
+func (w *rateLimitedWorkRequestClient) ListWorkRequestErrors(ctx context.Context,
+	req ociwr.ListWorkRequestErrorsRequest) (ociwr.ListWorkRequestErrorsResponse, error) {
+	return callWithReadLimit(ctx, w.limiter, "ListWorkRequestErrors", req,
+		func() (ociwr.ListWorkRequestErrorsResponse, error) {
+			return w.inner.ListWorkRequestErrors(ctx, req)
+		})
+}
+
+func (c *rateLimitedClusterPlacementGroupClient) GetClusterPlacementGroup(ctx context.Context,
+	req ocicpg.GetClusterPlacementGroupRequest) (ocicpg.GetClusterPlacementGroupResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "GetClusterPlacementGroup", req,
+		func() (ocicpg.GetClusterPlacementGroupResponse, error) {
+			return c.inner.GetClusterPlacementGroup(ctx, req)
+		})
+}
+
+func (c *rateLimitedClusterPlacementGroupClient) ListClusterPlacementGroups(ctx context.Context,
+	req ocicpg.ListClusterPlacementGroupsRequest) (ocicpg.ListClusterPlacementGroupsResponse, error) {
+	return callWithReadLimit(ctx, c.limiter, "ListClusterPlacementGroups", req,
+		func() (ocicpg.ListClusterPlacementGroupsResponse, error) {
+			return c.inner.ListClusterPlacementGroups(ctx, req)
+		})
+}
+
+func (k *kmsDecoratedClient) GetKey(ctx context.Context,
+	req ocikms.GetKeyRequest) (ocikms.GetKeyResponse, error) {
+	return callWithDecoratedReadLimit(ctx, k.limiter, "GetKey", req, func() (ocikms.GetKeyResponse, error) {
+		return k.inner.GetKey(ctx, req)
+	})
+}

--- a/pkg/oci/rate_limited_clients_test.go
+++ b/pkg/oci/rate_limited_clients_test.go
@@ -1,0 +1,75 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package oci
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/stretchr/testify/require"
+)
+
+type countingRateLimiter struct {
+	waitCalls int
+	waitErr   error
+}
+
+func (c *countingRateLimiter) TryAccept() bool {
+	return c.waitErr == nil
+}
+
+func (c *countingRateLimiter) Stop() {}
+
+func (c *countingRateLimiter) Accept() {}
+
+func (c *countingRateLimiter) QPS() float32 {
+	return 1
+}
+
+func (c *countingRateLimiter) Wait(context.Context) error {
+	c.waitCalls++
+	return c.waitErr
+}
+
+func TestRateLimitedComputeClient_UsesReaderLimiterForReadCalls(t *testing.T) {
+	reader := &countingRateLimiter{waitErr: errors.New("reader blocked")}
+	writer := &countingRateLimiter{}
+	client := &rateLimitedComputeClient{
+		inner: &ocicore.ComputeClient{},
+		limiter: RateLimiter{
+			Reader: reader,
+			Writer: writer,
+		},
+	}
+
+	_, err := client.GetInstance(context.Background(), ocicore.GetInstanceRequest{})
+
+	require.EqualError(t, err, "reader blocked")
+	require.Equal(t, 1, reader.waitCalls)
+	require.Equal(t, 0, writer.waitCalls)
+}
+
+func TestRateLimitedComputeClient_UsesWriterLimiterForWriteCalls(t *testing.T) {
+	reader := &countingRateLimiter{}
+	writer := &countingRateLimiter{waitErr: errors.New("writer blocked")}
+	client := &rateLimitedComputeClient{
+		inner: &ocicore.ComputeClient{},
+		limiter: RateLimiter{
+			Reader: reader,
+			Writer: writer,
+		},
+	}
+
+	_, err := client.LaunchInstance(context.Background(), ocicore.LaunchInstanceRequest{})
+
+	require.EqualError(t, err, "writer blocked")
+	require.Equal(t, 0, reader.waitCalls)
+	require.Equal(t, 1, writer.waitCalls)
+}

--- a/pkg/oci/rate_limiter.go
+++ b/pkg/oci/rate_limiter.go
@@ -1,0 +1,85 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package oci
+
+import (
+	"context"
+
+	"k8s.io/client-go/util/flowcontrol"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	defaultRateLimitQPSRead    float32 = 20
+	defaultRateLimitBurstRead          = 5
+	defaultRateLimitQPSWrite   float32 = 20
+	defaultRateLimitBurstWrite         = 5
+)
+
+type RateLimiterConfig struct {
+	DisableRateLimiter  bool
+	RateLimitQPSRead    float32
+	RateLimitBurstRead  int
+	RateLimitQPSWrite   float32
+	RateLimitBurstWrite int
+}
+
+type RateLimiter struct {
+	Reader flowcontrol.RateLimiter
+	Writer flowcontrol.RateLimiter
+}
+
+func NewRateLimiter(ctx context.Context, config *RateLimiterConfig) RateLimiter {
+	logger := log.FromContext(ctx)
+	if config == nil {
+		config = &RateLimiterConfig{}
+	}
+
+	if config.DisableRateLimiter {
+		logger.Info("OCI rate limiter is disabled")
+		return alwaysAllowRateLimiter()
+	}
+
+	if config.RateLimitQPSRead == 0 {
+		config.RateLimitQPSRead = defaultRateLimitQPSRead
+	}
+	if config.RateLimitBurstRead == 0 {
+		config.RateLimitBurstRead = defaultRateLimitBurstRead
+	}
+	if config.RateLimitQPSWrite == 0 {
+		config.RateLimitQPSWrite = defaultRateLimitQPSWrite
+	}
+	if config.RateLimitBurstWrite == 0 {
+		config.RateLimitBurstWrite = defaultRateLimitBurstWrite
+	}
+
+	logger.Info("OCI rate limiter is enabled",
+		"readQPS", config.RateLimitQPSRead,
+		"readBurst", config.RateLimitBurstRead,
+		"writeQPS", config.RateLimitQPSWrite,
+		"writeBurst", config.RateLimitBurstWrite)
+
+	return RateLimiter{
+		Reader: flowcontrol.NewTokenBucketRateLimiter(config.RateLimitQPSRead, config.RateLimitBurstRead),
+		Writer: flowcontrol.NewTokenBucketRateLimiter(config.RateLimitQPSWrite, config.RateLimitBurstWrite),
+	}
+}
+
+func normalizeRateLimiter(rateLimiter *RateLimiter) RateLimiter {
+	if rateLimiter != nil {
+		return *rateLimiter
+	}
+	return alwaysAllowRateLimiter()
+}
+
+func alwaysAllowRateLimiter() RateLimiter {
+	return RateLimiter{
+		Reader: flowcontrol.NewFakeAlwaysRateLimiter(),
+		Writer: flowcontrol.NewFakeAlwaysRateLimiter(),
+	}
+}

--- a/pkg/oci/rate_limiter_test.go
+++ b/pkg/oci/rate_limiter_test.go
@@ -1,0 +1,46 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package oci
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRateLimiter_Defaults(t *testing.T) {
+	rl := NewRateLimiter(context.Background(), &RateLimiterConfig{})
+
+	require.Equal(t, defaultRateLimitQPSRead, rl.Reader.QPS())
+	require.Equal(t, defaultRateLimitQPSWrite, rl.Writer.QPS())
+}
+
+func TestNewRateLimiter_DefaultBursts(t *testing.T) {
+	rl := NewRateLimiter(context.Background(), &RateLimiterConfig{
+		RateLimitQPSRead:  1,
+		RateLimitQPSWrite: 1,
+	})
+
+	for i := 0; i < defaultRateLimitBurstRead; i++ {
+		require.True(t, rl.Reader.TryAccept())
+	}
+	require.False(t, rl.Reader.TryAccept())
+
+	for i := 0; i < defaultRateLimitBurstWrite; i++ {
+		require.True(t, rl.Writer.TryAccept())
+	}
+	require.False(t, rl.Writer.TryAccept())
+}
+
+func TestNewRateLimiter_Disabled(t *testing.T) {
+	rl := NewRateLimiter(context.Background(), &RateLimiterConfig{DisableRateLimiter: true})
+
+	require.NoError(t, rl.Reader.Wait(context.Background()))
+	require.NoError(t, rl.Writer.Wait(context.Background()))
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -108,10 +108,17 @@ func createOperator(ctx context.Context, coreOp *operator.Operator,
 
 	shapeMetaFile = valueOrDefault(shapeMetaFile, DefaultShapeMetafileCluster)
 	refreshInterval := time.Duration(ociOptions.ShapeMetaRefreshIntervalHours) * time.Hour
+	rateLimiter := oci.NewRateLimiter(ctx, &oci.RateLimiterConfig{
+		DisableRateLimiter:  ociOptions.DisableRateLimiter,
+		RateLimitQPSRead:    float32(ociOptions.RateLimitQPSRead),
+		RateLimitBurstRead:  ociOptions.RateLimitBurstRead,
+		RateLimitQPSWrite:   float32(ociOptions.RateLimitQPSWrite),
+		RateLimitBurstWrite: ociOptions.RateLimitBurstWrite,
+	})
 
 	ociClient := inputOciClient
 	if ociClient == nil {
-		ociClient = lo.Must(oci.NewClient(ctx, configProvider))
+		ociClient = lo.Must(oci.NewClient(ctx, configProvider, &rateLimiter))
 	}
 
 	capacityReservationProvider := capacityreservation.NewProvider(ctx, ociClient,
@@ -149,7 +156,7 @@ func createOperator(ctx context.Context, coreOp *operator.Operator,
 	imageProvider := lo.Must(image.NewProvider(ctx, clientSet, ociClient,
 		ociOptions.PreBakedImageCompartmentId, "", coreOp.Elected()))
 
-	kmsKeyProvider := lo.Must(kms.NewProvider(ctx, ociOptions.ClusterCompartmentId, configProvider))
+	kmsKeyProvider := lo.Must(kms.NewProvider(ctx, ociOptions.ClusterCompartmentId, configProvider, &rateLimiter))
 
 	blockStorageProvider := lo.Must(blockstorage.NewProvider(ctx, ociClient))
 

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -41,6 +41,11 @@ type Options struct {
 	InstanceLaunchTimeoutBMMins            int
 	InstanceOperationPollIntervalInSeconds int
 	InstanceLaunchTimeOutFailOver          bool
+	DisableRateLimiter                     bool
+	RateLimitQPSRead                       float64
+	RateLimitBurstRead                     int
+	RateLimitQPSWrite                      float64
+	RateLimitBurstWrite                    int
 	setFlags                               map[string]bool
 	parsed                                 bool
 }
@@ -112,6 +117,16 @@ Example in a JSON format:
 		"Intervals in seconds to decide how often instance operation result is checked")
 	fs.BoolVar(&o.InstanceLaunchTimeOutFailOver, "instance-launch-timeout-failover", false,
 		"When instance launch timeout happens, fail over to next instance types")
+	fs.BoolVar(&o.DisableRateLimiter, "disable-rate-limiter", true,
+		"Disable the OCI client-side rate limiter")
+	fs.Float64Var(&o.RateLimitQPSRead, "rate-limit-qps-read", 0,
+		"Read QPS for the OCI client-side rate limiter. 0 uses the default")
+	fs.IntVar(&o.RateLimitBurstRead, "rate-limit-burst-read", 0,
+		"Read burst for the OCI client-side rate limiter. 0 uses the default")
+	fs.Float64Var(&o.RateLimitQPSWrite, "rate-limit-qps-write", 0,
+		"Write QPS for the OCI client-side rate limiter. 0 uses the default")
+	fs.IntVar(&o.RateLimitBurstWrite, "rate-limit-burst-write", 0,
+		"Write burst for the OCI client-side rate limiter. 0 uses the default")
 
 	fs.Var((*RepairPoliciesValue)(&o.RepairPolicies),
 		"repair-policies",
@@ -200,6 +215,18 @@ func (o *Options) Validate() error {
 
 	if o.InstanceLaunchTimeoutBMMins <= 0 {
 		return errors.New("delete-instance-timeout-bm-mins must be a positive integer")
+	}
+	if o.RateLimitQPSRead < 0 {
+		return errors.New("rate-limit-qps-read must be greater than or equal to 0")
+	}
+	if o.RateLimitBurstRead < 0 {
+		return errors.New("rate-limit-burst-read must be greater than or equal to 0")
+	}
+	if o.RateLimitQPSWrite < 0 {
+		return errors.New("rate-limit-qps-write must be greater than or equal to 0")
+	}
+	if o.RateLimitBurstWrite < 0 {
+		return errors.New("rate-limit-burst-write must be greater than or equal to 0")
 	}
 
 	return nil

--- a/pkg/operator/options/options_test.go
+++ b/pkg/operator/options/options_test.go
@@ -118,6 +118,19 @@ var _ = Describe("Test Operator Options", func() {
 				},
 				"",
 			},
+			{
+				&Options{
+					ClusterCompartmentId:          "testClusterCompartmentId",
+					VcnCompartmentId:              "testVcnCompartmentId",
+					PreBakedImageCompartmentId:    "testPreBakedImageCompartmentId",
+					ApiserverEndpoint:             "1.0.10.1",
+					ShapeMetaRefreshIntervalHours: 1,
+					InstanceLaunchTimeoutVMMins:   1,
+					InstanceLaunchTimeoutBMMins:   1,
+					RateLimitQPSRead:              -1,
+				},
+				"rate-limit-qps-read must be greater than or equal to 0",
+			},
 		}
 
 		for _, tc := range testCases {
@@ -155,6 +168,11 @@ var _ = Describe("Test Operator Options", func() {
 			"instance-launch-timeout-bm-mins",
 			"instance-operation-poll-interval-seconds",
 			"instance-launch-timeout-failover",
+			"disable-rate-limiter",
+			"rate-limit-qps-read",
+			"rate-limit-burst-read",
+			"rate-limit-qps-write",
+			"rate-limit-burst-write",
 			"repair-policies",
 			"pre-baked-image-compartment-id",
 			"shape-meta-file",
@@ -199,6 +217,15 @@ var _ = Describe("Test Operator Options", func() {
 			"--instance-operation-poll-interval-seconds",
 			"5",
 			"--instance-launch-timeout-failover", // "true"
+			"--disable-rate-limiter",
+			"--rate-limit-qps-read",
+			"21",
+			"--rate-limit-burst-read",
+			"6",
+			"--rate-limit-qps-write",
+			"11",
+			"--rate-limit-burst-write",
+			"3",
 			"--repair-policies",
 			"[{\"ConditionType\": \"Ready\",\"ConditionStatus\": \"False\",\"TolerationDuration\": 600000000000}]",
 			"--pre-baked-image-compartment-id",
@@ -233,6 +260,11 @@ var _ = Describe("Test Operator Options", func() {
 		Expect(o.InstanceLaunchTimeoutBMMins).To(Equal(30))
 		Expect(o.InstanceOperationPollIntervalInSeconds).To(Equal(5))
 		Expect(o.InstanceLaunchTimeOutFailOver).To(BeTrue())
+		Expect(o.DisableRateLimiter).To(BeTrue())
+		Expect(o.RateLimitQPSRead).To(Equal(float64(21)))
+		Expect(o.RateLimitBurstRead).To(Equal(6))
+		Expect(o.RateLimitQPSWrite).To(Equal(float64(11)))
+		Expect(o.RateLimitBurstWrite).To(Equal(3))
 		Expect(o.RepairPolicies).To(ContainElements(cloudprovider.RepairPolicy{
 			ConditionType:      corev1.NodeReady,
 			ConditionStatus:    corev1.ConditionFalse,

--- a/pkg/providers/kms/provider.go
+++ b/pkg/providers/kms/provider.go
@@ -31,6 +31,7 @@ type Provider interface {
 type DefaultProvider struct {
 	clusterCompartmentOcid string
 	configProvider         common.ConfigurationProvider
+	rateLimiter            *oci.RateLimiter
 	kmsOcidCache           *cache.GetOrLoadCache[*ocikms.Key]
 	kmsFilterCache         *cache.GetOrLoadCache[[]*ocikms.KeySummary]
 	kmsClientCache         map[string]oci.KmsClient
@@ -38,11 +39,17 @@ type DefaultProvider struct {
 }
 
 func NewProvider(ctx context.Context,
-	clusterCompartmentOcid string, configProvider common.ConfigurationProvider) (*DefaultProvider, error) {
+	clusterCompartmentOcid string, configProvider common.ConfigurationProvider,
+	rateLimiter ...*oci.RateLimiter) (*DefaultProvider, error) {
+	var limiter *oci.RateLimiter
+	if len(rateLimiter) > 0 {
+		limiter = rateLimiter[0]
+	}
 
 	p := &DefaultProvider{
 		configProvider:         configProvider,
 		clusterCompartmentOcid: clusterCompartmentOcid,
+		rateLimiter:            limiter,
 		kmsOcidCache:           cache.NewDefaultGetOrLoadCache[*ocikms.Key](),
 		kmsFilterCache:         cache.NewDefaultGetOrLoadCache[[]*ocikms.KeySummary](),
 		kmsClientCache:         make(map[string]oci.KmsClient),
@@ -68,7 +75,7 @@ func (p *DefaultProvider) getKmsClient(endpoint string) (oci.KmsClient, error) {
 	if ok {
 		return c, nil
 	} else {
-		nc, err := oci.NewKmsClient(p.configProvider, endpoint)
+		nc, err := oci.NewKmsClient(p.configProvider, endpoint, p.rateLimiter)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

This PR adds a client-side OCI rate limiter to Karpenter Provider OCI to help control request volume sent to OCI APIs.

# What Changed
Added a shared OCI rate limiter with separate read and write token buckets.
Wrapped OCI service clients with rate-limited client adapters for OCI APIs

This PR adds the following settings:

```
disable-rate-limiter
rate-limit-qps-read
rate-limit-burst-read
rate-limit-qps-write
rate-limit-burst-write
```

Helm values:

```
settings.rateLimiter.disable
settings.rateLimiter.qpsRead
settings.rateLimiter.burstRead
settings.rateLimiter.qpsWrite
settings.rateLimiter.burstWrite
```

#  Default Behaviour
The OCI rate limiter is disabled by default.
When enabled, zero values fall back to built-in defaults:

Read QPS: 20
Read Burst: 5
Write QPS: 20
Write Burst: 5