### PR TITLE
Npn IPCount Validation Against Subnet Number of CIDRs

### DIFF
--- a/pkg/oci/rate_limited_clients.go
+++ b/pkg/oci/rate_limited_clients.go
@@ -170,9 +170,10 @@ func (c *rateLimitedComputeClient) GetComputeCluster(ctx context.Context,
 
 func (c *rateLimitedComputeClient) ListComputeClusters(ctx context.Context,
 	req ocicore.ListComputeClustersRequest) (ocicore.ListComputeClustersResponse, error) {
-	return callWithReadLimit(ctx, c.limiter, "ListComputeClusters", req, func() (ocicore.ListComputeClustersResponse, error) {
-		return c.inner.ListComputeClusters(ctx, req)
-	})
+	return callWithReadLimit(ctx, c.limiter, "ListComputeClusters", req,
+		func() (ocicore.ListComputeClustersResponse, error) {
+			return c.inner.ListComputeClusters(ctx, req)
+		})
 }
 
 func (c *rateLimitedComputeClient) GetImage(ctx context.Context,

--- a/pkg/providers/network/provider.go
+++ b/pkg/providers/network/provider.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
@@ -122,6 +123,11 @@ func (p *DefaultProvider) ResolveNetworkConfig(ctx context.Context,
 					vnicConfig.SimpleVnicConfig, fmt.Sprintf("second vnic %d", idx))
 				if err != nil {
 					errs = multierr.Append(errs, err)
+				} else {
+					cidrNumberValidationError := p.validateSecondaryVnicIpCountsAgainstCidrs(vnicConfig, subnetAndNsg)
+					if cidrNumberValidationError != nil {
+						errs = multierr.Append(errs, cidrNumberValidationError)
+					}
 				}
 
 				otherVnicSubnetAndNsgs = append(otherVnicSubnetAndNsgs, &subnetAndNsg)
@@ -150,10 +156,7 @@ IPv6 will have some additional restrictions
 func (p *DefaultProvider) validateSecondaryVnicIpCounts(networkCfg *v1beta1.NetworkConfig) error {
 	ipCountSum := 0
 	for _, vnicConfig := range networkCfg.SecondaryVnicConfigs {
-		ipCountVal := GetDefaultSecondaryVnicIPCount(p.ipFamilies)
-		if vnicConfig.IpCount != nil {
-			ipCountVal = *vnicConfig.IpCount
-		}
+		ipCountVal := p.ipCountToCheck(vnicConfig)
 
 		if ipCountVal > 256 {
 			return errors.New("max IP count per VNIC can't be over 256")
@@ -175,6 +178,61 @@ func (p *DefaultProvider) validateSecondaryVnicIpCounts(networkCfg *v1beta1.Netw
 		return errors.New("total IP count of all VNICs can't be over 256")
 	}
 	return nil
+}
+
+/*
+If the subnet only has one CIDR block for IPv6 enabled cluster and assigned IPv6 IP, the max allowed IP is 16,
+If the subnet only has one CIDR block for IPv4 subnet, the max allowed IP is 32
+*/
+func (p *DefaultProvider) validateSecondaryVnicIpCountsAgainstCidrs(vnicConfig *v1beta1.SecondaryVnicConfig,
+	subnetAndNsg SubnetAndNsgs) error {
+	ipCountVal := p.ipCountToCheck(vnicConfig)
+	if subnetAndNsg.Subnet != nil {
+		//When the subnet is resolved, and it is IPv6 enabled and assigned IPv6 IP, for single CIDR block, KPO only allows <=16 IPs
+		if IsIPv6(p.ipFamilies) && vnicConfig.AssignIpV6Ip != nil && *vnicConfig.AssignIpV6Ip {
+			ipV6CidrBlocks := getCidrBlocks(subnetAndNsg.Subnet.Ipv6CidrBlock, subnetAndNsg.Subnet.Ipv6CidrBlocks)
+
+			if len(ipV6CidrBlocks) == 1 && ipCountVal > 16 {
+				return errors.New(fmt.Sprintf("max IP count for single CIDR IPv6 subnet '%s' can't over 16",
+					strPtrToStr(subnetAndNsg.Subnet.Id)))
+			}
+		} else {
+			//When the subnet is resolved and IPv6, for single CIDR block, it only allows <=32 IPs
+			ipv4CidrBlocks := getCidrBlocks(subnetAndNsg.Subnet.CidrBlock, subnetAndNsg.Subnet.Ipv4CidrBlocks)
+			if len(ipv4CidrBlocks) == 1 && ipCountVal > 32 {
+				return errors.New(fmt.Sprintf("max IP count for single CIDR IPv4 subnet '%s' can't over 32",
+					strPtrToStr(subnetAndNsg.Subnet.Id)))
+			}
+		}
+	}
+	return nil
+}
+
+/*
+*
+According the ocicore Subnet contract. CidrBlock or Ipv6CidrBlock is the default cidr block of the subnet,
+Ipv4CidrBlocks or Ipv6CidrBlocks contains all Cidr blocks it has, which will include all cidr blocks including
+the one from CidrBlock or Ipv6CidrBlock. In theory Ipv4CidrBlocks or Ipv6CidrBlocks will not be nil or empty.
+This code is just for any unexpect situations if Ipv4CidrBlocks or Ipv6CidrBlocks is empty, we will use default
+cider blocks for the check instead.
+*/
+func getCidrBlocks(defaultCidrBlock *string, allCidrBlocks []string) []string {
+	cidrBlocks := make([]string, 0)
+	if len(allCidrBlocks) == 0 && defaultCidrBlock != nil &&
+		strings.TrimSpace(*defaultCidrBlock) != "" {
+		cidrBlocks = append(cidrBlocks, *defaultCidrBlock)
+	} else {
+		cidrBlocks = allCidrBlocks
+	}
+	return cidrBlocks
+}
+
+func (p *DefaultProvider) ipCountToCheck(vnicConfig *v1beta1.SecondaryVnicConfig) int {
+	ipCountVal := GetDefaultSecondaryVnicIPCount(p.ipFamilies)
+	if vnicConfig.IpCount != nil {
+		ipCountVal = *vnicConfig.IpCount
+	}
+	return ipCountVal
 }
 
 func (p *DefaultProvider) resolveSimpleVnicConfig(ctx context.Context, config v1beta1.SimpleVnicConfig,
@@ -461,4 +519,12 @@ func (p *DefaultProvider) GetVnicCached(ctx context.Context, vnicOcid string) (*
 	return p.vnicCache.GetOrLoad(ctx, vnicOcid, func(ctx context.Context, key string) (*ocicore.Vnic, error) {
 		return p.getVnicImpl(ctx, key)
 	})
+}
+
+func strPtrToStr(strValue *string) string {
+	if strValue == nil {
+		return ""
+	}
+
+	return *strValue
 }

--- a/pkg/providers/network/provider.go
+++ b/pkg/providers/network/provider.go
@@ -188,20 +188,21 @@ func (p *DefaultProvider) validateSecondaryVnicIpCountsAgainstCidrs(vnicConfig *
 	subnetAndNsg SubnetAndNsgs) error {
 	ipCountVal := p.ipCountToCheck(vnicConfig)
 	if subnetAndNsg.Subnet != nil {
-		//When the subnet is resolved, and it is IPv6 enabled and assigned IPv6 IP, for single CIDR block, KPO only allows <=16 IPs
+		// When the subnet is resolved, and it is IPv6 enabled and assigned IPv6 IP,
+		// for single CIDR block, KPO only allows <=16 IPs
 		if IsIPv6(p.ipFamilies) && vnicConfig.AssignIpV6Ip != nil && *vnicConfig.AssignIpV6Ip {
 			ipV6CidrBlocks := getCidrBlocks(subnetAndNsg.Subnet.Ipv6CidrBlock, subnetAndNsg.Subnet.Ipv6CidrBlocks)
 
 			if len(ipV6CidrBlocks) == 1 && ipCountVal > 16 {
-				return errors.New(fmt.Sprintf("max IP count for single CIDR IPv6 subnet '%s' can't over 16",
-					strPtrToStr(subnetAndNsg.Subnet.Id)))
+				return fmt.Errorf("max IP count for single CIDR IPv6 subnet '%s' can't over 16",
+					strPtrToStr(subnetAndNsg.Subnet.Id))
 			}
 		} else {
-			//When the subnet is resolved and IPv6, for single CIDR block, it only allows <=32 IPs
+			// When the subnet is resolved and IPv6, for single CIDR block, it only allows <=32 IPs
 			ipv4CidrBlocks := getCidrBlocks(subnetAndNsg.Subnet.CidrBlock, subnetAndNsg.Subnet.Ipv4CidrBlocks)
 			if len(ipv4CidrBlocks) == 1 && ipCountVal > 32 {
-				return errors.New(fmt.Sprintf("max IP count for single CIDR IPv4 subnet '%s' can't over 32",
-					strPtrToStr(subnetAndNsg.Subnet.Id)))
+				return fmt.Errorf("max IP count for single CIDR IPv4 subnet '%s' can't over 32",
+					strPtrToStr(subnetAndNsg.Subnet.Id))
 			}
 		}
 	}

--- a/pkg/providers/network/provider_test.go
+++ b/pkg/providers/network/provider_test.go
@@ -670,6 +670,7 @@ func TestResolveNetworkConfig_FlexCiderValidation(t *testing.T) {
 		ipFamily     []IpFamily
 		sVnicIds     []string
 		sVnicIpCount []*int
+		assignIPv6   *bool
 		expectedErr  *string
 	}{
 		{
@@ -677,29 +678,34 @@ func TestResolveNetworkConfig_FlexCiderValidation(t *testing.T) {
 			[]string{"subnet-dual"},
 			[]*int{lo.ToPtr(16)},
 			nil,
+			nil,
 		},
 		{
 			[]IpFamily{IPv4},
 			[]string{"subnet-dual"},
 			[]*int{lo.ToPtr(512)},
+			nil,
 			lo.ToPtr("max IP count per VNIC can't be over 256"),
 		},
 		{
 			[]IpFamily{IPv4},
 			[]string{"subnet-dual"},
 			[]*int{lo.ToPtr(34)},
+			nil,
 			lo.ToPtr("IP count must be power of 2"),
 		},
 		{
 			[]IpFamily{IPv4, IPv6},
 			[]string{"subnet-dual"},
 			[]*int{lo.ToPtr(34)},
+			nil,
 			lo.ToPtr("IP count must be power of 2"),
 		},
 		{
 			[]IpFamily{IPv6},
 			[]string{"subnet-dual"},
 			[]*int{lo.ToPtr(32)},
+			nil,
 			lo.ToPtr("single stack IPv6 nodepool only IP count 1, 16 and 256 will be supported"),
 		},
 		{
@@ -707,11 +713,13 @@ func TestResolveNetworkConfig_FlexCiderValidation(t *testing.T) {
 			[]string{"subnet-dual"},
 			[]*int{lo.ToPtr(1)},
 			nil,
+			nil,
 		},
 		{
 			[]IpFamily{IPv6},
 			[]string{"subnet-dual"},
 			[]*int{lo.ToPtr(16)},
+			nil,
 			nil,
 		},
 		{
@@ -719,11 +727,13 @@ func TestResolveNetworkConfig_FlexCiderValidation(t *testing.T) {
 			[]string{"subnet-dual"},
 			[]*int{lo.ToPtr(256)},
 			nil,
+			nil,
 		},
 		{
 			[]IpFamily{IPv4},
 			[]string{"subnet-dual", "subnet-dual", "subnet-dual"},
 			[]*int{lo.ToPtr(128), lo.ToPtr(128), lo.ToPtr(128)},
+			nil,
 			lo.ToPtr("total IP count of all VNICs can't be over 256"),
 		},
 		// Test for default ipCount
@@ -732,16 +742,19 @@ func TestResolveNetworkConfig_FlexCiderValidation(t *testing.T) {
 			[]string{"subnet-dual", "subnet-dual"},
 			nil,
 			nil,
+			nil,
 		},
 		{
 			[]IpFamily{IPv4, IPv6},
 			[]string{"subnet-dual"},
 			nil,
 			nil,
+			nil,
 		},
 		{
 			[]IpFamily{IPv6},
 			[]string{"subnet-dual"},
+			nil,
 			nil,
 			nil,
 		},
@@ -749,7 +762,64 @@ func TestResolveNetworkConfig_FlexCiderValidation(t *testing.T) {
 			[]IpFamily{IPv6},
 			[]string{"subnet-dual", "subnet-dual"},
 			nil,
+			nil,
 			lo.ToPtr("total IP count of all VNICs can't be over 256"),
+		},
+		{
+			[]IpFamily{IPv4},
+			[]string{"subnet-single-v4-cidr"},
+			nil,
+			nil,
+			nil,
+		},
+		{
+			[]IpFamily{IPv4},
+			[]string{"subnet-single-v4-cidr"},
+			[]*int{lo.ToPtr(64)},
+			nil,
+			lo.ToPtr("max IP count for single CIDR IPv4 subnet 'subnet-single-v4-cidr' can't over 32"),
+		},
+		{
+			[]IpFamily{IPv4},
+			[]string{"subnet-single-v4-cidr", "subnet-single-v4-cidr"},
+			[]*int{lo.ToPtr(64), lo.ToPtr(128)},
+			nil,
+			lo.ToPtr("max IP count for single CIDR IPv4 subnet 'subnet-single-v4-cidr' can't over 32; max IP count for single CIDR IPv4 subnet 'subnet-single-v4-cidr' can't over 32"),
+		},
+		{
+			[]IpFamily{IPv4, IPv6},
+			[]string{"subnet-single-v6-cidr"},
+			nil,
+			nil, // Singe IPv6 CIDR but not assigning IPv6 IP
+			nil,
+		},
+		{
+			[]IpFamily{IPv4, IPv6},
+			[]string{"subnet-dual"},
+			nil,
+			lo.ToPtr(true), // Assigning IPv6 IP but have two CIDRs
+			nil,
+		},
+		{
+			[]IpFamily{IPv4, IPv6},
+			[]string{"subnet-single-v6-cidr"},
+			nil,
+			lo.ToPtr(true),
+			lo.ToPtr("max IP count for single CIDR IPv6 subnet 'subnet-single-v6-cidr' can't over 16"),
+		},
+		{
+			[]IpFamily{IPv4, IPv6},
+			[]string{"subnet-single-v6-cidr"},
+			[]*int{lo.ToPtr(256)},
+			lo.ToPtr(true),
+			lo.ToPtr("max IP count for single CIDR IPv6 subnet 'subnet-single-v6-cidr' can't over 16"),
+		},
+		{
+			[]IpFamily{IPv4, IPv6},
+			[]string{"subnet-single-v6-cidr", "subnet-single-v6-cidr"},
+			[]*int{lo.ToPtr(256), nil},
+			lo.ToPtr(true),
+			lo.ToPtr("total IP count of all VNICs can't be over 256; max IP count for single CIDR IPv6 subnet 'subnet-single-v6-cidr' can't over 16; max IP count for single CIDR IPv6 subnet 'subnet-single-v6-cidr' can't over 16"),
 		},
 	}
 
@@ -772,6 +842,7 @@ func TestResolveNetworkConfig_FlexCiderValidation(t *testing.T) {
 								SubnetId: &subnetId,
 							},
 						},
+						AssignIpV6Ip: tc.assignIPv6,
 					},
 					IpCount: ipCount,
 				})
@@ -796,5 +867,74 @@ func TestResolveNetworkConfig_FlexCiderValidation(t *testing.T) {
 			assert.NotNil(t, result)
 		}
 	}
+}
 
+func TestValidateSecondaryVnicIpCountsAgainstCidrs_SingleCidr_EmptyCidrBlockList(t *testing.T) {
+	provider, _ := newProviderForNetworkTests([]IpFamily{IPv4, IPv6}, true)
+
+	t.Run("Ipv6CidrBlocks empty, Ipv6CidrBlock set, AssignIpV6Ip set, exceed max", func(t *testing.T) {
+		subnet := &ocicore.Subnet{
+			Id:             lo.ToPtr("test-v6-subnet"),
+			Ipv6CidrBlocks: []string{},
+			Ipv6CidrBlock:  lo.ToPtr("2001:db8::/56"),
+		}
+		vnicConfig := &v1beta1.SecondaryVnicConfig{
+			SimpleVnicConfig: v1beta1.SimpleVnicConfig{
+				AssignIpV6Ip: lo.ToPtr(true),
+			},
+			IpCount: lo.ToPtr(32),
+		}
+		sn := SubnetAndNsgs{Subnet: subnet}
+		err := provider.validateSecondaryVnicIpCountsAgainstCidrs(vnicConfig, sn)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "max IP count for single CIDR IPv6 subnet")
+	})
+
+	t.Run("Ipv6CidrBlocks empty, Ipv6CidrBlock set, AssignIpV6Ip set, within max", func(t *testing.T) {
+		subnet := &ocicore.Subnet{
+			Id:             lo.ToPtr("test-v6-subnet"),
+			Ipv6CidrBlocks: []string{},
+			Ipv6CidrBlock:  lo.ToPtr("2001:db8::/56"),
+		}
+		vnicConfig := &v1beta1.SecondaryVnicConfig{
+			SimpleVnicConfig: v1beta1.SimpleVnicConfig{
+				AssignIpV6Ip: lo.ToPtr(true),
+			},
+			IpCount: lo.ToPtr(16),
+		}
+		sn := SubnetAndNsgs{Subnet: subnet}
+		err := provider.validateSecondaryVnicIpCountsAgainstCidrs(vnicConfig, sn)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Ipv4CidrBlocks empty, CidrBlock set, not IPv6, exceed max", func(t *testing.T) {
+		provider, _ := newProviderForNetworkTests([]IpFamily{IPv4}, true)
+		subnet := &ocicore.Subnet{
+			Id:             lo.ToPtr("test-v4-subnet"),
+			Ipv4CidrBlocks: []string{},
+			CidrBlock:      lo.ToPtr("10.0.0.0/24"),
+		}
+		vnicConfig := &v1beta1.SecondaryVnicConfig{
+			IpCount: lo.ToPtr(64),
+		}
+		sn := SubnetAndNsgs{Subnet: subnet}
+		err := provider.validateSecondaryVnicIpCountsAgainstCidrs(vnicConfig, sn)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "max IP count for single CIDR IPv4 subnet")
+	})
+
+	t.Run("Ipv4CidrBlocks empty, CidrBlock set, not IPv6, within max", func(t *testing.T) {
+		provider, _ := newProviderForNetworkTests([]IpFamily{IPv4}, true)
+		subnet := &ocicore.Subnet{
+			Id:             lo.ToPtr("test-v4-subnet"),
+			Ipv4CidrBlocks: []string{},
+			CidrBlock:      lo.ToPtr("10.0.0.0/24"),
+		}
+		vnicConfig := &v1beta1.SecondaryVnicConfig{
+			IpCount: lo.ToPtr(16),
+		}
+		sn := SubnetAndNsgs{Subnet: subnet}
+		err := provider.validateSecondaryVnicIpCountsAgainstCidrs(vnicConfig, sn)
+		assert.NoError(t, err)
+	})
 }

--- a/pkg/providers/network/provider_test.go
+++ b/pkg/providers/network/provider_test.go
@@ -784,7 +784,8 @@ func TestResolveNetworkConfig_FlexCiderValidation(t *testing.T) {
 			[]string{"subnet-single-v4-cidr", "subnet-single-v4-cidr"},
 			[]*int{lo.ToPtr(64), lo.ToPtr(128)},
 			nil,
-			lo.ToPtr("max IP count for single CIDR IPv4 subnet 'subnet-single-v4-cidr' can't over 32; max IP count for single CIDR IPv4 subnet 'subnet-single-v4-cidr' can't over 32"),
+			lo.ToPtr("max IP count for single CIDR IPv4 subnet 'subnet-single-v4-cidr' can't over 32; " +
+				"max IP count for single CIDR IPv4 subnet 'subnet-single-v4-cidr' can't over 32"),
 		},
 		{
 			[]IpFamily{IPv4, IPv6},
@@ -819,7 +820,9 @@ func TestResolveNetworkConfig_FlexCiderValidation(t *testing.T) {
 			[]string{"subnet-single-v6-cidr", "subnet-single-v6-cidr"},
 			[]*int{lo.ToPtr(256), nil},
 			lo.ToPtr(true),
-			lo.ToPtr("total IP count of all VNICs can't be over 256; max IP count for single CIDR IPv6 subnet 'subnet-single-v6-cidr' can't over 16; max IP count for single CIDR IPv6 subnet 'subnet-single-v6-cidr' can't over 16"),
+			lo.ToPtr("total IP count of all VNICs can't be over 256; " +
+				"max IP count for single CIDR IPv6 subnet 'subnet-single-v6-cidr' can't over 16; " +
+				"max IP count for single CIDR IPv6 subnet 'subnet-single-v6-cidr' can't over 16"),
 		},
 	}
 

--- a/pkg/providers/network/resolve_result.go
+++ b/pkg/providers/network/resolve_result.go
@@ -78,6 +78,10 @@ func IsIPv6SingleStack(ipFamilies []IpFamily) bool {
 	return len(ipFamilies) == 1 && slices.Contains(ipFamilies, IPv6)
 }
 
+func IsIPv6(ipFamilies []IpFamily) bool {
+	return slices.Contains(ipFamilies, IPv6)
+}
+
 func GetDefaultSecondaryVnicIPCount(ipFamilies []IpFamily) int {
 	if IsIPv6SingleStack(ipFamilies) {
 		return DefaultIPv6SecondaryVnicIPCount


### PR DESCRIPTION
Npn IPCount Validation Against Subnet Number of CIDRs

# Description
Add Npn Cluster Secondary VNIC IPCount Validation Against Subnet Number of CIDRs

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x]  New unit tests passed
- [x]  Manual test results
<img width="1475" height="776" alt="Screenshot 2026-05-15 at 10 55 41" src="https://github.com/user-attachments/assets/725feceb-218c-484a-8ddb-14d685271dc1" />
<img width="1478" height="699" alt="Screenshot 2026-05-15 at 10 55 51" src="https://github.com/user-attachments/assets/d616748a-1c55-4828-827b-29c7dd3644ff" />

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules