### PR TITLE
Fix to consider extra VNICs for extra OCPUs for Flex Shapes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ GIT_SHA?=$(shell git describe --dirty --always)
 TAG_PREFIX=v0.0.1
 VERSION=$(TAG_PREFIX)-$(GIT_SHA)-$(BUILD_NUM)
 IMG ?= $(REG)/karpenter-provider-oci:$(VERSION)
+export GOTOOLCHAIN ?= go1.26.1
 CGO_ENABLED?=0
 BUILDOPTS:=-v
 GOOS ?= linux

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ GIT_SHA?=$(shell git describe --dirty --always)
 TAG_PREFIX=v0.0.1
 VERSION=$(TAG_PREFIX)-$(GIT_SHA)-$(BUILD_NUM)
 IMG ?= $(REG)/karpenter-provider-oci:$(VERSION)
-export GOTOOLCHAIN ?= go1.26.1
 CGO_ENABLED?=0
 BUILDOPTS:=-v
 GOOS ?= linux

--- a/pkg/providers/instancetype/provider.go
+++ b/pkg/providers/instancetype/provider.go
@@ -316,7 +316,7 @@ func (p *DefaultProvider) decorateInstanceType(ctx context.Context, it *OciInsta
 	vnicAvailable := true
 	secondVnicsNum := -1
 	if shape.MaxVnicAttachments != nil {
-		secondVnicsNum = *shape.MaxVnicAttachments - 1
+		secondVnicsNum = p.getMaxVnicAttachmentsForShape(ctx, shape, ocpu) - 1
 	}
 
 	if nodeClass.Spec.NetworkConfig.SecondaryVnicConfigs != nil &&
@@ -335,6 +335,55 @@ func (p *DefaultProvider) decorateInstanceType(ctx context.Context, it *OciInsta
 	}
 
 	return err
+}
+
+/*
+If shape is a Flexible shape and selected Ocpu number larger than Min Ocpu options
+Then work out the maxSecondaryVnicAttachements from MaxVnicAttachmentOptions
+
+	minVnic + (ocpu - minOcpu) * defaultVnicPerOcpu
+
+Otherwise return shape.maxVnicAttahments
+*/
+func (p *DefaultProvider) getMaxVnicAttachmentsForShape(ctx context.Context, shape *ocicore.Shape, ocpu float32) int {
+
+	if shape.IsFlexible != nil && *shape.IsFlexible &&
+		isValidMaxVnicAttachmentOptions(shape.MaxVnicAttachmentOptions) &&
+		isValidOcpuOptions(shape.OcpuOptions) {
+		minOcpu := *shape.OcpuOptions.Min
+		if ocpu > minOcpu {
+			vnicMin := float32(*shape.MaxVnicAttachmentOptions.Min)
+			vnicMax := *shape.MaxVnicAttachmentOptions.Max
+			vnicPerOcpu := float32(1)
+			if shape.MaxVnicAttachmentOptions.DefaultPerOcpu != nil {
+				vnicPerOcpu = *shape.MaxVnicAttachmentOptions.DefaultPerOcpu
+			}
+
+			maxPossibleVnics := vnicMin + (ocpu-minOcpu)*vnicPerOcpu
+			if maxPossibleVnics > vnicMax {
+				maxPossibleVnics = vnicMax
+			}
+
+			log.FromContext(ctx).V(1).Info("MaxVnicAttachmentDetails",
+				"vnicMin", vnicMin, "vnicMax", vnicMax, "vnicPerOcpu",
+				vnicPerOcpu, "maxPossibleVnics", maxPossibleVnics)
+			return int(maxPossibleVnics)
+		} else {
+			return *shape.MaxVnicAttachmentOptions.Min // when ocpu<=minOcpu using *shape.MaxVnicAttachmentOptions.Min
+		}
+	}
+
+	return *shape.MaxVnicAttachments
+}
+
+func isValidMaxVnicAttachmentOptions(maxVnicAttachmentOptions *ocicore.ShapeMaxVnicAttachmentOptions) bool {
+	return maxVnicAttachmentOptions != nil &&
+		maxVnicAttachmentOptions.Min != nil &&
+		maxVnicAttachmentOptions.Max != nil
+}
+
+func isValidOcpuOptions(ocpuOptions *ocicore.ShapeOcpuOptions) bool {
+	return ocpuOptions != nil && ocpuOptions.Min != nil
 }
 
 func makeOnDemandOffering(shapeName string, ads []string, price float64, available bool,

--- a/pkg/providers/instancetype/provider_test.go
+++ b/pkg/providers/instancetype/provider_test.go
@@ -2144,3 +2144,149 @@ func TestListInstanceTypes_GPUShapeWithNoTaints(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, its)
 }
+
+func TestGetMaxVnicAttachmentsForShape(t *testing.T) {
+	tests := []struct {
+		name               string
+		isFlexible         *bool
+		ocpuOptions        *ocicore.ShapeOcpuOptions
+		maxVnicOpts        *ocicore.ShapeMaxVnicAttachmentOptions
+		maxVnicAttachments *int
+		ocpu               float32
+		want               int
+	}{
+		{
+			name:        "flexible, ocpu == min value",
+			isFlexible:  lo.ToPtr(true),
+			ocpuOptions: &ocicore.ShapeOcpuOptions{Min: lo.ToPtr(float32(2))},
+			maxVnicOpts: &ocicore.ShapeMaxVnicAttachmentOptions{
+				Min:            lo.ToPtr(4),
+				Max:            lo.ToPtr(float32(10)),
+				DefaultPerOcpu: lo.ToPtr(float32(2))},
+			maxVnicAttachments: lo.ToPtr(2),
+			ocpu:               2,
+			want:               4, // falls back to ShapeMaxVnicAttachmentOptions.Min
+		},
+		{
+			name:        "flexible, ocpu > min but result in bounds",
+			isFlexible:  lo.ToPtr(true),
+			ocpuOptions: &ocicore.ShapeOcpuOptions{Min: lo.ToPtr(float32(2))},
+			maxVnicOpts: &ocicore.ShapeMaxVnicAttachmentOptions{
+				Min:            lo.ToPtr(4),
+				Max:            lo.ToPtr(float32(10)),
+				DefaultPerOcpu: lo.ToPtr(float32(2))},
+			maxVnicAttachments: lo.ToPtr(2),
+			ocpu:               4, // ocpuDiff = 2, maxPossible = 4 + 2*2 = 8
+			want:               8,
+		},
+		{
+			name:        "flexible, ocpu > min but hits max",
+			isFlexible:  lo.ToPtr(true),
+			ocpuOptions: &ocicore.ShapeOcpuOptions{Min: lo.ToPtr(float32(2))},
+			maxVnicOpts: &ocicore.ShapeMaxVnicAttachmentOptions{
+				Min:            lo.ToPtr(4),
+				Max:            lo.ToPtr(float32(7)),
+				DefaultPerOcpu: lo.ToPtr(float32(2))},
+			maxVnicAttachments: lo.ToPtr(2),
+			ocpu:               5, // ocpuDiff = 3, maxPossible = 4 + 3*2 = 10 -> hits 7
+			want:               7,
+		},
+		{
+			name:               "non-flexible shape",
+			isFlexible:         lo.ToPtr(false),
+			maxVnicAttachments: lo.ToPtr(4),
+			ocpu:               2,
+			want:               4,
+		},
+		{
+			name:               "missing isFlexible returns MaxVnicAttachments",
+			isFlexible:         nil,
+			maxVnicAttachments: lo.ToPtr(2),
+			ocpu:               4,
+			want:               2,
+		},
+		{
+			name:               "missing maxVnicOpts falls back to MaxVnicAttachments",
+			isFlexible:         lo.ToPtr(true),
+			ocpuOptions:        &ocicore.ShapeOcpuOptions{Min: lo.ToPtr(float32(2))},
+			maxVnicOpts:        nil,
+			maxVnicAttachments: lo.ToPtr(2),
+			ocpu:               8,
+			want:               2,
+		},
+		{
+			name:        "missing maxVnicOpts.Min falls back to MaxVnicAttachments",
+			isFlexible:  lo.ToPtr(true),
+			ocpuOptions: &ocicore.ShapeOcpuOptions{Min: lo.ToPtr(float32(2))},
+			maxVnicOpts: &ocicore.ShapeMaxVnicAttachmentOptions{
+				Min:            nil,
+				Max:            lo.ToPtr(float32(10)),
+				DefaultPerOcpu: lo.ToPtr(float32(2))},
+			maxVnicAttachments: lo.ToPtr(2),
+			ocpu:               8,
+			want:               2,
+		},
+		{
+			name:        "missing maxVnicOpts.Max falls back to MaxVnicAttachments",
+			isFlexible:  lo.ToPtr(true),
+			ocpuOptions: &ocicore.ShapeOcpuOptions{Min: lo.ToPtr(float32(2))},
+			maxVnicOpts: &ocicore.ShapeMaxVnicAttachmentOptions{
+				Min:            lo.ToPtr(4),
+				Max:            nil,
+				DefaultPerOcpu: lo.ToPtr(float32(2))},
+			maxVnicAttachments: lo.ToPtr(2),
+			ocpu:               8,
+			want:               2,
+		},
+		{
+			name:        "nil ocpuOptions falls back to MaxVnicAttachments",
+			isFlexible:  lo.ToPtr(true),
+			ocpuOptions: nil,
+			maxVnicOpts: &ocicore.ShapeMaxVnicAttachmentOptions{
+				Min:            lo.ToPtr(4),
+				Max:            lo.ToPtr(float32(10)),
+				DefaultPerOcpu: lo.ToPtr(float32(2))},
+			maxVnicAttachments: lo.ToPtr(2),
+			ocpu:               6,
+			want:               2,
+		},
+		{
+			name:        "nil ocpuOptions.Min falls back to MaxVnicAttachments",
+			isFlexible:  lo.ToPtr(true),
+			ocpuOptions: nil,
+			maxVnicOpts: &ocicore.ShapeMaxVnicAttachmentOptions{
+				Min:            lo.ToPtr(4),
+				Max:            lo.ToPtr(float32(10)),
+				DefaultPerOcpu: lo.ToPtr(float32(2))},
+			maxVnicAttachments: lo.ToPtr(2),
+			ocpu:               6,
+			want:               2,
+		},
+		{
+			name:        "flexible, defaultPerOcpu is nil",
+			isFlexible:  lo.ToPtr(true),
+			ocpuOptions: &ocicore.ShapeOcpuOptions{Min: lo.ToPtr(float32(2))},
+			maxVnicOpts: &ocicore.ShapeMaxVnicAttachmentOptions{
+				Min:            lo.ToPtr(4),
+				Max:            lo.ToPtr(float32(10)),
+				DefaultPerOcpu: nil},
+			maxVnicAttachments: lo.ToPtr(2),
+			ocpu:               4, // ocpuDiff = 2, maxPossible = 4 + 2*1 = 6
+			want:               6,
+		},
+	}
+
+	p := &DefaultProvider{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shape := &ocicore.Shape{
+				IsFlexible:               tt.isFlexible,
+				OcpuOptions:              tt.ocpuOptions,
+				MaxVnicAttachmentOptions: tt.maxVnicOpts,
+				MaxVnicAttachments:       tt.maxVnicAttachments,
+			}
+			got := p.getMaxVnicAttachmentsForShape(context.Background(), shape, tt.ocpu)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -335,6 +335,7 @@ func TestKarpenterE2ENpn(t *testing.T) {
 		s.TestScaleUp()
 		s.TestNodeOverlay()
 		s.TestNpnDriftDetection()
+		s.TestFlexShapeMultipleVnics()
 		s.TestScaleDown()
 		s.TestStaticCapacity()
 	})
@@ -634,6 +635,16 @@ func (s *E2ETestSuite) TestShapeConfig() {
 		},
 	}
 
+	s.patchAndVerifyShapeConfigs(cases, nodePool)
+}
+
+func (s *E2ETestSuite) patchAndVerifyShapeConfigs(cases []struct {
+	name         string
+	patchFunc    func(*ociv1beta1.OCINodeClass)
+	verifyFunc   func(*corev1.Node, any) bool
+	capacityType string
+	expected     string
+}, nodePool *karpenterv1.NodePool) {
 	for _, tc := range cases {
 		s.t.Run(tc.name, func(t *testing.T) {
 			t.Logf("Start %s shape config testing", tc.name)
@@ -654,6 +665,41 @@ func (s *E2ETestSuite) TestShapeConfig() {
 			s.t.Logf("%s shape config test successful", tc.name)
 		})
 	}
+}
+
+func (s *E2ETestSuite) TestFlexShapeMultipleVnics() {
+	s.t.Log("Start Flex Shape Multiple Vnics testing")
+	s.ensureDeploymentReplicas(s.testConfig.TestDeployment.Name, s.testConfig.Namespace,
+		s.testConfig.TestDeployment.Replicas)
+	nodePool := &karpenterv1.NodePool{}
+	require.NoError(s.t, s.ctrlClient.Get(s.ctx, client.ObjectKey{Name: s.testConfig.NodePool.Name}, nodePool))
+
+	cases := []struct {
+		name         string
+		patchFunc    func(*ociv1beta1.OCINodeClass)
+		verifyFunc   func(*corev1.Node, any) bool
+		capacityType string
+		expected     string
+	}{
+		{
+			name: "FexShapeMultipleVnicsTest",
+			patchFunc: func(p *ociv1beta1.OCINodeClass) {
+				p.Spec.ShapeConfigs = createShapeConfig(s.testConfig.OCINodeClass.ShapeConfigs)
+				newSecondaryVnicList := make([]*ociv1beta1.SecondaryVnicConfig, 0)
+				newSecondaryVnicList = append(newSecondaryVnicList, p.Spec.NetworkConfig.SecondaryVnicConfigs[0])
+				newSecondaryVnicConfig := p.Spec.NetworkConfig.SecondaryVnicConfigs[0].DeepCopy()
+				newSecondaryVnicConfig.VnicDisplayName = lo.ToPtr("SVnic2")
+				newSecondaryVnicList = append(newSecondaryVnicList, newSecondaryVnicConfig)
+
+				p.Spec.NetworkConfig.SecondaryVnicConfigs = newSecondaryVnicList
+			},
+			verifyFunc:   s.verifyShapeConfig,
+			capacityType: karpenterv1.CapacityTypeOnDemand,
+			expected:     "VM.Standard.E4.Flex.8o.64g.1_1b",
+		},
+	}
+
+	s.patchAndVerifyShapeConfigs(cases, nodePool)
 }
 
 func (s *E2ETestSuite) TestCapacityReservation() {

--- a/test/e2e/testdata/e2e_test_config_npn.template
+++ b/test/e2e/testdata/e2e_test_config_npn.template
@@ -39,6 +39,12 @@
       "VAR_NSG1_ID"
     ],
     "NsgName": "VAR_NSG1_NAME",
+    "ShapeConfigs": [
+          {
+            "ocpus": 8,
+            "memoryInGbs": 64
+          }
+        ],
     "SecondVnicConfigs": [
       {
         "VnicDisplayname": "SVnic1",


### PR DESCRIPTION
# Description

Fix an issue that KPO max VNICs calculation of Flex Shapes which does not taking extra VNICs into consideration when increasing number of OCPUs.

Fixes # https://github.com/oracle/karpenter-provider-oci/issues/20

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] New unit tests passed
- [x] Manual tests passed
<img width="669" height="137" alt="Screenshot 2026-05-20 at 11 19 42" src="https://github.com/user-attachments/assets/f808e055-b426-42a2-bfb7-383c09bf6bc7" />
<img width="1920" height="812" alt="Screenshot 2026-05-20 at 11 41 58" src="https://github.com/user-attachments/assets/e9329d0f-5b84-4ed1-9619-1f67097f587e" />
<img width="828" height="122" alt="Screenshot 2026-05-20 at 11 42 35" src="https://github.com/user-attachments/assets/8cc77aa2-947c-413f-8834-64f8c8b324c2" />
<img width="1248" height="802" alt="Screenshot 2026-05-21 at 16 40 39" src="https://github.com/user-attachments/assets/9ce3e8bd-4b77-4c9e-b947-b56d9db9ab51" />

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules