### PR TITLE
fix: orphan controller should not delete the instances that are not owned by the cluster

### DIFF
--- a/docs/guide/oci-resource-discovery-and-reclaiming.md
+++ b/docs/guide/oci-resource-discovery-and-reclaiming.md
@@ -33,7 +33,7 @@ If you need to force cleanup (for example, after partial failures), inspect fina
 
 ### OCI-side discovery
 
-Instances launched by Karpenter will have the `KarpenterNodePool` freeform tag. You can use:
+Instances launched by Karpenter will have `KarpenterNodePool` and `KarpenterNodePoolUID` freeform tags. `KarpenterNodePoolUID` identifies the Kubernetes NodePool that launched the instance. You can use:
 - **OCI Resource Explorer** to find instances by tags: [Querying resources](https://docs.oracle.com/en-us/iaas/Content/Search/Tasks/queryingresources.htm)
 - **OCI CLI Search** (optional) to list resources by structured search:
 
@@ -41,5 +41,7 @@ Instances launched by Karpenter will have the `KarpenterNodePool` freeform tag. 
 oci search resource structured-search --query-text \
   "query instance resources where (freeformTags.key = 'KarpenterNodePool')"
 ```
+
+Instances created by older KPO versions might not have `KarpenterNodePoolUID`. KPO falls back to the legacy `KarpenterNodePool` name match for those instances.
 
 When deleting a cluster, ensure that any Karpenter-managed instances (and any dependent resources they created) are also deleted.

--- a/docs/reference/helm-chart.md
+++ b/docs/reference/helm-chart.md
@@ -83,6 +83,11 @@ A Helm chart for Karpenter provider OCI
 | settings.ipFamilies | list | `["IPv4"]` | by default only IPv4, add IPv6 in needed |
 | settings.ociVcnIpNative | bool | `false` | set this to true for a cluster run with OciVcnIpNative |
 | settings.preBakedImageCompartmentId | string | `"ocid1.compartment.oc1..aaaaaaaab4u67dhgtj5gpdpp3z42xqqsdnufxkatoild46u3hb67vzojfmzq"` | Compartment OCID under which OKE pre-baked images are published |
+| settings.rateLimiter.burstRead | int | `0` | Read burst for the OCI client-side rate limiter. 0 uses the built-in default. |
+| settings.rateLimiter.burstWrite | int | `0` | Write burst for the OCI client-side rate limiter. 0 uses the built-in default. |
+| settings.rateLimiter.disable | bool | `true` | Disable the OCI client-side rate limiter. |
+| settings.rateLimiter.qpsRead | int | `0` | Read QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
+| settings.rateLimiter.qpsWrite | int | `0` | Write QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
 | settings.vcnCompartmentId | string | `""` | [required] Cluster's VCN compartment OCID. |
 | strategy | object | `{"rollingUpdate":{"maxUnavailable":1}}` | Strategy for updating the pod. |
 | terminationGracePeriodSeconds | string | `nil` | Override the default termination grace period for the pod. |

--- a/pkg/cloudprovider/cloud_provider.go
+++ b/pkg/cloudprovider/cloud_provider.go
@@ -484,6 +484,10 @@ func (c *CloudProvider) List(ctx context.Context) ([]*corev1.NodeClaim, error) {
 		return item.Name
 	})...)
 
+	nodePoolUIDByName := lo.SliceToMap(nodePoolList.Items, func(item corev1.NodePool) (string, string) {
+		return item.Name, string(item.UID)
+	})
+
 	for _, compartmentId := range nodeCompartments {
 		ins, err = c.instanceProvider.ListInstances(ctx, compartmentId)
 		if err != nil {
@@ -491,6 +495,11 @@ func (c *CloudProvider) List(ctx context.Context) ([]*corev1.NodeClaim, error) {
 		}
 
 		for _, i := range ins {
+			nodePoolName, ok := instance.GetNodePoolNameFromInstance(i)
+			if !ok || !isInstanceOwnedByNodePool(i, nodePoolUIDByName[nodePoolName]) {
+				continue
+			}
+
 			nodeClaim, inerr := c.createNodeClaimFromInstance(ctx, i)
 			if inerr != nil {
 				return nil, inerr
@@ -505,6 +514,15 @@ func (c *CloudProvider) List(ctx context.Context) ([]*corev1.NodeClaim, error) {
 	}
 
 	return nodeClaims, nil
+}
+
+func isInstanceOwnedByNodePool(i *ocicore.Instance, expectedNodePoolUID string) bool {
+	nodePoolUID, ok := instance.GetNodePoolUIDFromInstance(i)
+	if !ok {
+		return true
+	}
+
+	return nodePoolUID != "" && expectedNodePoolUID == nodePoolUID
 }
 
 func (c *CloudProvider) getOciInstanceTypes(ctx context.Context,

--- a/pkg/cloudprovider/cloud_provider_test.go
+++ b/pkg/cloudprovider/cloud_provider_test.go
@@ -39,6 +39,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -50,6 +51,7 @@ import (
 
 const (
 	nodeClassClusterCompartmentID = "ocid1.compartment.oc1..cluster123"
+	sharedCompartmentID           = "ocid1.compartment.oc1..shared"
 	testImageID                   = "ocid1.image.oc1..test"
 )
 
@@ -120,7 +122,12 @@ var _ = Describe("CloudProvider Integration Tests", func() {
 		nodeClassPtr := &ociTestNodeClass
 		ExpectApplied(ctx, k8sClient, nodeClassPtr)
 		ExpectObjectReconciled(ctx, k8sClient, ociNodeClassController, nodeClassPtr)
+		nodePool := testNodePool("pool-a", nodeClassPtr.Name)
+		ExpectApplied(ctx, k8sClient, nodePool)
 		nodeClaimPtr := &v1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{v1.NodePoolLabelKey: nodePool.Name},
+			},
 			Spec: v1.NodeClaimSpec{
 				NodeClassRef: &v1.NodeClassReference{
 					Kind:  nodeClassPtr.Kind,
@@ -379,6 +386,25 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			Expect(cp.Delete(context.Background(), nodeClaim)).To(Succeed())
 			Expect(released).To(ContainElement("ocid1.capacityreservation.oc1..abc"))
 		})
+
+		It("should trust nodeclaim provider ID when deleting tagged instances", func() {
+			deleteCalled := false
+			cp.instanceProvider = &FakeInstanceProvider{
+				GetInstanceFn: func(context.Context, string) (*instance.InstanceInfo, error) {
+					i := testInstanceWithShape("shape-a", "pool-a")
+					i.Id = lo.ToPtr(nodeClaim.Status.ProviderID)
+					i.FreeformTags[instance.NodePoolUIDOciFreeFormTagKey] = "other-nodepool-uid"
+					return &instance.InstanceInfo{Instance: i}, nil
+				},
+				DeleteInstanceFn: func(context.Context, string) error {
+					deleteCalled = true
+					return nil
+				},
+			}
+
+			Expect(cp.Delete(context.Background(), nodeClaim)).To(Succeed())
+			Expect(deleteCalled).To(BeTrue())
+		})
 	})
 
 	Context("List", func() {
@@ -412,11 +438,89 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			Expect(nodeClaims).To(HaveLen(1))
 			Expect(nodeClaims[0].Labels[v1.NodePoolLabelKey]).To(Equal(nodePool.Name))
 		})
+
+		It("should include instances when nodepool name and UID match", func() {
+			nodeClass := testReadyNodeClass(uniqueName("used"))
+			compartment := sharedCompartmentID
+			nodeClass.Spec.NodeCompartmentId = &compartment
+			nodePool := testNodePoolWithUID(uniqueName("nodepool"), nodeClass.Name)
+			localInstance := testInstanceWithShape("shape-a", nodePool.Name)
+			localInstance.FreeformTags[instance.NodePoolUIDOciFreeFormTagKey] = string(nodePool.UID)
+
+			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+				kubeClient:    newFakeKubeClient(nodeClass, nodePool),
+				instanceTypes: []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+				instanceProvider: &FakeInstanceProvider{
+					ListInstancesFn: func(_ context.Context, _ string) ([]*ocicore.Instance, error) {
+						return []*ocicore.Instance{localInstance}, nil
+					},
+				},
+			})
+
+			nodeClaims, err := cp.List(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodeClaims).To(HaveLen(1))
+			Expect(nodeClaims[0].Labels[v1.NodePoolLabelKey]).To(Equal(nodePool.Name))
+		})
+
+		It("should exclude instances owned by another nodepool UID even when nodepool names match", func() {
+			nodeClass := testReadyNodeClass(uniqueName("used"))
+			compartment := sharedCompartmentID
+			nodeClass.Spec.NodeCompartmentId = &compartment
+			nodePool := testNodePoolWithUID(uniqueName("nodepool"), nodeClass.Name)
+			foreignInstance := testInstanceWithShape("shape-a", nodePool.Name)
+			foreignInstance.FreeformTags[instance.NodePoolUIDOciFreeFormTagKey] = "other-nodepool-uid"
+
+			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+				kubeClient:    newFakeKubeClient(nodeClass, nodePool),
+				instanceTypes: []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+				instanceProvider: &FakeInstanceProvider{
+					ListInstancesFn: func(_ context.Context, _ string) ([]*ocicore.Instance, error) {
+						return []*ocicore.Instance{foreignInstance}, nil
+					},
+				},
+			})
+
+			nodeClaims, err := cp.List(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodeClaims).To(BeEmpty())
+		})
+
+		It("should include legacy untagged instances when nodepool name matches", func() {
+			nodeClass := testReadyNodeClass(uniqueName("used"))
+			compartment := sharedCompartmentID
+			nodeClass.Spec.NodeCompartmentId = &compartment
+			nodePool := testNodePool("pool-a", nodeClass.Name)
+
+			ownedLegacy := testInstanceWithShape("shape-a", nodePool.Name)
+			ownedLegacy.Id = lo.ToPtr("ocid1.instance.oc1..legacy-owned")
+			delete(ownedLegacy.FreeformTags, instance.NodePoolUIDOciFreeFormTagKey)
+
+			unownedLegacy := testInstanceWithShape("shape-a", nodePool.Name)
+			unownedLegacy.Id = lo.ToPtr("ocid1.instance.oc1..legacy-unowned")
+			delete(unownedLegacy.FreeformTags, instance.NodePoolUIDOciFreeFormTagKey)
+
+			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+				kubeClient:    newFakeKubeClient(nodeClass, nodePool),
+				instanceTypes: []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+				instanceProvider: &FakeInstanceProvider{
+					ListInstancesFn: func(_ context.Context, _ string) ([]*ocicore.Instance, error) {
+						return []*ocicore.Instance{ownedLegacy, unownedLegacy}, nil
+					},
+				},
+			})
+
+			nodeClaims, err := cp.List(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodeClaims).To(HaveLen(2))
+		})
+
 	})
 
 	Context("Create", func() {
 		var (
 			nodeClass   *v1beta1.OCINodeClass
+			nodePool    *v1.NodePool
 			kubeClient  client.Client
 			nodeClaim   *v1.NodeClaim
 			instanceA   *instancetype.OciInstanceType
@@ -426,7 +530,8 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 
 		BeforeEach(func() {
 			nodeClass = testReadyNodeClass(uniqueName("create"))
-			kubeClient = newFakeKubeClient(nodeClass)
+			nodePool = testNodePoolWithUID("pool-a", nodeClass.Name)
+			kubeClient = newFakeKubeClient(nodeClass, nodePool)
 			nodeClaim = testNodeClaim(nodeClass.Name)
 			instanceA = testInstanceType("shape-a", 10)
 			instanceB = testInstanceType("shape-b", 20)
@@ -773,6 +878,12 @@ func testNodePool(name, nodeClassName string) *v1.NodePool {
 			},
 		},
 	}
+}
+
+func testNodePoolWithUID(name, nodeClassName string) *v1.NodePool {
+	nodePool := testNodePool(name, nodeClassName)
+	nodePool.UID = types.UID(name + "-uid")
+	return nodePool
 }
 
 func testInstanceType(shape string, price float64) *instancetype.OciInstanceType {

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -124,8 +124,8 @@ func getFirstFoundEnvTestBinaryDir() string {
 type FakeInstanceProvider struct {
 	TestInstance     *instance.InstanceInfo
 	LaunchInstanceFn func(context.Context, *corev1.NodeClaim, *ocioraclecouldcomv1beta1.OCINodeClass,
-		*instancetype.OciInstanceType, *image.ImageResolveResult, *network.NetworkResolveResult,
-		*kms.KmsKeyResolveResult, *placement.Proposal) (*instance.InstanceInfo, error)
+		*instancetype.OciInstanceType, *image.ImageResolveResult, *network.NetworkResolveResult, *kms.KmsKeyResolveResult,
+		*placement.Proposal) (*instance.InstanceInfo, error)
 	DeleteInstanceFn                    func(context.Context, string) error
 	GetInstanceFn                       func(context.Context, string) (*instance.InstanceInfo, error)
 	GetInstanceCachedFn                 func(context.Context, string) (*instance.InstanceInfo, error)

--- a/pkg/providers/instance/provider.go
+++ b/pkg/providers/instance/provider.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/awslabs/operatorpkg/object"
 	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
 	"github.com/oracle/karpenter-provider-oci/pkg/cache"
 	"github.com/oracle/karpenter-provider-oci/pkg/oci"
@@ -36,6 +37,7 @@ import (
 
 const (
 	NodePoolOciFreeFormTagKey      = "KarpenterNodePool"
+	NodePoolUIDOciFreeFormTagKey   = "KarpenterNodePoolUID"
 	NodeClassOciFreeFormTagKey     = "KarpenterNodeClass"
 	NodeClassHashOciFreeFormTagKey = "Karpenter_NodeClass_Hash"
 )
@@ -165,6 +167,11 @@ func (p *DefaultProvider) LaunchInstance(ctx context.Context,
 
 	launchOptions := BuildLaunchOptions(nodeClass.Spec.LaunchOptions)
 
+	freeFormTags, err := buildFreeFormTags(nodeClass, nodeClaim)
+	if err != nil {
+		return nil, err
+	}
+
 	// construct launch instance request.
 	launchRequest := ocicore.LaunchInstanceRequest{
 		LaunchInstanceDetails: ocicore.LaunchInstanceDetails{
@@ -178,7 +185,7 @@ func (p *DefaultProvider) LaunchInstance(ctx context.Context,
 				nodeClass.Spec.NetworkConfig.PrimaryVnicConfig),
 			DefinedTags:               buildDefinedTags(nodeClass.Spec.DefinedTags),
 			DisplayName:               &nodeClaim.Name,
-			FreeformTags:              buildFreeFormTags(nodeClass, nodeClaim),
+			FreeformTags:              freeFormTags,
 			Metadata:                  metadata,
 			PreemptibleInstanceConfig: preemptibleInstanceConfig, // preemptible support
 			Shape:                     &instanceType.Shape,
@@ -618,6 +625,17 @@ func GetNodePoolNameFromInstance(instance *ocicore.Instance) (string, bool) {
 	return "", false
 }
 
+func GetNodePoolUIDFromInstance(instance *ocicore.Instance) (string, bool) {
+	if instance.FreeformTags != nil {
+		v, ok := instance.FreeformTags[NodePoolUIDOciFreeFormTagKey]
+		if ok {
+			return v, true
+		}
+	}
+
+	return "", false
+}
+
 func GetNodeClassHashFromInstance(instance *ocicore.Instance) (string, bool) {
 	if instance.FreeformTags != nil {
 		v, ok := instance.FreeformTags[NodeClassHashOciFreeFormTagKey]
@@ -629,7 +647,7 @@ func GetNodeClassHashFromInstance(instance *ocicore.Instance) (string, bool) {
 	return "", false
 }
 
-func buildFreeFormTags(nodeClass *v1beta1.OCINodeClass, nodeClaim *corev1.NodeClaim) map[string]string {
+func buildFreeFormTags(nodeClass *v1beta1.OCINodeClass, nodeClaim *corev1.NodeClaim) (map[string]string, error) {
 	freeFormTags := make(map[string]string)
 	if nodeClass.Spec.FreeformTags != nil {
 		freeFormTags = lo.Assign(freeFormTags, nodeClass.Spec.FreeformTags)
@@ -652,7 +670,29 @@ func buildFreeFormTags(nodeClass *v1beta1.OCINodeClass, nodeClaim *corev1.NodeCl
 		freeFormTags[NodeClassHashOciFreeFormTagKey] = val
 	}
 
-	return freeFormTags
+	nodePoolUID, ok := nodePoolUIDFromNodeClaimOwnerReference(nodeClaim)
+	if !ok {
+		return nil, fmt.Errorf("nodeclaim %s is missing NodePool owner reference UID", nodeClaim.Name)
+	}
+	if nodePoolUID != "" {
+		freeFormTags[NodePoolUIDOciFreeFormTagKey] = nodePoolUID
+	}
+
+	return freeFormTags, nil
+}
+
+func nodePoolUIDFromNodeClaimOwnerReference(nodeClaim *corev1.NodeClaim) (string, bool) {
+	nodePoolGVK := object.GVK(&corev1.NodePool{})
+	owner, ok := lo.Find(nodeClaim.GetOwnerReferences(), func(owner metav1.OwnerReference) bool {
+		if owner.APIVersion == nodePoolGVK.GroupVersion().String() &&
+			owner.Kind == nodePoolGVK.Kind &&
+			owner.UID != "" {
+			return true
+		}
+
+		return false
+	})
+	return string(owner.UID), ok
 }
 
 func DecorateNodeClaimByInstance(nodeClaim *corev1.NodeClaim, i *ocicore.Instance) {

--- a/pkg/providers/instance/provider_test.go
+++ b/pkg/providers/instance/provider_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/awslabs/operatorpkg/object"
 	ociv1beta1 "github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
 	"github.com/oracle/karpenter-provider-oci/pkg/cache"
 	"github.com/oracle/karpenter-provider-oci/pkg/fakes"
@@ -88,7 +89,18 @@ func minimalNodeClaim() *corev1.NodeClaim {
 				corev1.NodePoolLabelKey: "poolA",
 				ociv1beta1.NodeClass:    "classA",
 			},
+			OwnerReferences: []metav1.OwnerReference{nodePoolOwnerReference("poolA")},
 		},
+	}
+}
+
+func nodePoolOwnerReference(name string) metav1.OwnerReference {
+	nodePoolGVK := object.GVK(&corev1.NodePool{})
+	return metav1.OwnerReference{
+		APIVersion: nodePoolGVK.GroupVersion().String(),
+		Kind:       nodePoolGVK.Kind,
+		Name:       name,
+		UID:        "nodepool-uid",
 	}
 }
 
@@ -320,6 +332,7 @@ func TestProvider_GetNodePoolAndClassHashFromInstance(t *testing.T) {
 	inst := &ocicore.Instance{
 		FreeformTags: map[string]string{
 			NodePoolOciFreeFormTagKey:      "np",
+			NodePoolUIDOciFreeFormTagKey:   "nodepool-uid",
 			NodeClassHashOciFreeFormTagKey: "hash",
 		},
 	}
@@ -331,10 +344,16 @@ func TestProvider_GetNodePoolAndClassHashFromInstance(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "hash", h)
 
+	nodePoolUID, ok := GetNodePoolUIDFromInstance(inst)
+	assert.True(t, ok)
+	assert.Equal(t, "nodepool-uid", nodePoolUID)
+
 	empty := &ocicore.Instance{}
 	_, ok = GetNodePoolNameFromInstance(empty)
 	assert.False(t, ok)
 	_, ok = GetNodeClassHashFromInstance(empty)
+	assert.False(t, ok)
+	_, ok = GetNodePoolUIDFromInstance(empty)
 	assert.False(t, ok)
 }
 
@@ -350,18 +369,38 @@ func TestProvider_BuildFreeFormTags(t *testing.T) {
 		},
 	}
 	nclaim := &corev1.NodeClaim{
-		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-			corev1.NodePoolLabelKey: "pool1",
-			ociv1beta1.NodeClass:    "class1",
-		}},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				corev1.NodePoolLabelKey: "pool1",
+				ociv1beta1.NodeClass:    "class1",
+			},
+			OwnerReferences: []metav1.OwnerReference{nodePoolOwnerReference("pool1")},
+		},
 	}
-	got := buildFreeFormTags(nc, nclaim)
+	got, err := buildFreeFormTags(nc, nclaim)
+	require.NoError(t, err)
 	_, ok := got["a"]
 	assert.True(t, ok)
 	assert.Equal(t, "1", got["a"])
 	assert.Equal(t, "pool1", got[NodePoolOciFreeFormTagKey])
+	assert.Equal(t, "nodepool-uid", got[NodePoolUIDOciFreeFormTagKey])
 	assert.Equal(t, "class1", got[NodeClassOciFreeFormTagKey])
 	assert.Equal(t, "hash123", got[NodeClassHashOciFreeFormTagKey])
+}
+
+func TestProvider_BuildFreeFormTagsRequiresNodePoolOwnerReferenceUID(t *testing.T) {
+	got, err := buildFreeFormTags(minimalNodeClass(), &corev1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nc-missing-owner",
+			Labels: map[string]string{
+				corev1.NodePoolLabelKey: "pool1",
+				ociv1beta1.NodeClass:    "class1",
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "missing NodePool owner reference UID")
 }
 
 func TestProvider_DecorateNodeClaimByInstance(t *testing.T) {
@@ -733,7 +772,8 @@ func TestProvider_LaunchInstance_RequestConstruction(t *testing.T) {
 		it.Offerings = cloudprovider.Offerings{makeOfferingWithCapType(corev1.CapacityTypeSpot)}
 		nodeClass := baseNodeClass.DeepCopy()
 
-		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass, it, imgRes, netRes, nil, pp)
+		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass,
+			it, imgRes, netRes, nil, pp)
 		require.NoError(t, err)
 		require.NotNil(t, fc.LastLaunchReq.LaunchInstanceDetails.PreemptibleInstanceConfig, "expected preemptible config")
 	})
@@ -747,7 +787,8 @@ func TestProvider_LaunchInstance_RequestConstruction(t *testing.T) {
 		it.Offerings = cloudprovider.Offerings{makeOfferingWithCapType(corev1.CapacityTypeOnDemand)}
 		nodeClass := baseNodeClass.DeepCopy()
 
-		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass, it, imgRes, netRes, nil, pp)
+		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass,
+			it, imgRes, netRes, nil, pp)
 		require.NoError(t, err)
 		require.Nil(t, fc.LastLaunchReq.LaunchInstanceDetails.ShapeConfig, "did not expect shape config")
 	})
@@ -769,7 +810,8 @@ func TestProvider_LaunchInstance_RequestConstruction(t *testing.T) {
 		it.Offerings = cloudprovider.Offerings{makeOfferingWithCapType(corev1.CapacityTypeOnDemand)}
 		nodeClass := baseNodeClass.DeepCopy()
 
-		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass, it, imgRes, netRes, nil, pp)
+		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass,
+			it, imgRes, netRes, nil, pp)
 		require.NoError(t, err)
 		require.NotNil(t, fc.LastLaunchReq.LaunchInstanceDetails.ShapeConfig, "expected shape config")
 		require.Equal(t, *fc.LastLaunchReq.LaunchInstanceDetails.ShapeConfig.Ocpus, ocpu, "ocpu should match")
@@ -790,7 +832,8 @@ func TestProvider_LaunchInstance_RequestConstruction(t *testing.T) {
 		it.Offerings = cloudprovider.Offerings{makeOfferingWithCapType(corev1.CapacityTypeSpot)}
 		nodeClass := baseNodeClass.DeepCopy()
 
-		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass, it, imgRes, netRes, nil, pp)
+		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass,
+			it, imgRes, netRes, nil, pp)
 		require.NoError(t, err)
 		require.Nil(t, fc.LastLaunchReq.LaunchInstanceDetails.PreemptibleInstanceConfig,
 			"burstable should not be preemptible")
@@ -813,7 +856,8 @@ func TestProvider_LaunchInstance_RequestConstruction(t *testing.T) {
 		// provide kms key
 		k := &kms.KmsKeyResolveResult{Ocid: "ocid1.key.oc1.iad.xxxxx"}
 
-		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass, it, imgRes, netRes, k, pp)
+		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass,
+			it, imgRes, netRes, k, pp)
 		require.NoError(t, err)
 
 		// Assert IMDS v1 disabled
@@ -870,7 +914,8 @@ func TestProvider_LaunchInstance_RequestConstruction(t *testing.T) {
 			},
 		}
 
-		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass, it, imgRes, nr, nil, pp)
+		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass,
+			it, imgRes, nr, nil, pp)
 		require.NoError(t, err)
 
 		// Validate VNIC details precedence
@@ -890,6 +935,7 @@ func TestProvider_LaunchInstance_RequestConstruction(t *testing.T) {
 
 		// Validate freeform/defined tags
 		require.Equal(t, "poolZ", fc.LastLaunchReq.LaunchInstanceDetails.FreeformTags[NodePoolOciFreeFormTagKey])
+		require.Equal(t, "nodepool-uid", fc.LastLaunchReq.LaunchInstanceDetails.FreeformTags[NodePoolUIDOciFreeFormTagKey])
 		require.Equal(t, "classZ", fc.LastLaunchReq.LaunchInstanceDetails.FreeformTags[NodeClassOciFreeFormTagKey])
 		require.Equal(t, "h123", fc.LastLaunchReq.LaunchInstanceDetails.FreeformTags[NodeClassHashOciFreeFormTagKey])
 		require.Equal(t, "v1", fc.LastLaunchReq.LaunchInstanceDetails.DefinedTags["ns"]["k1"])
@@ -1022,8 +1068,9 @@ func TestProvider_LaunchInstance_FailurePaths(t *testing.T) {
 
 	t.Run("launch error propagates", func(t *testing.T) {
 		fc.LaunchErr = errors.New("launch failed")
-		_, err := p.LaunchInstance(context.TODO(), baseClaim, baseNodeClass, &instancetype.OciInstanceType{
-			Shape: "VM.Standard.E4.Flex"}, imgRes, netRes, nil, pp)
+		_, err := p.LaunchInstance(context.TODO(), baseClaim, baseNodeClass,
+			&instancetype.OciInstanceType{
+				Shape: "VM.Standard.E4.Flex"}, imgRes, netRes, nil, pp)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "launch failed")
 		fc.LaunchErr = nil // reset
@@ -1031,8 +1078,9 @@ func TestProvider_LaunchInstance_FailurePaths(t *testing.T) {
 
 	t.Run("retryable error", func(t *testing.T) {
 		fc.LaunchErr = errors.New("TooManyRequests: rate limited")
-		_, err := p.LaunchInstance(context.TODO(), baseClaim, baseNodeClass, &instancetype.OciInstanceType{
-			Shape: "VM.Standard.E4.Flex"}, imgRes, netRes, nil, pp)
+		_, err := p.LaunchInstance(context.TODO(), baseClaim, baseNodeClass,
+			&instancetype.OciInstanceType{
+				Shape: "VM.Standard.E4.Flex"}, imgRes, netRes, nil, pp)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "rate limited")
 		fc.LaunchErr = nil
@@ -1224,8 +1272,7 @@ func TestProvider_LaunchInstance_WorkRequestSuccess(t *testing.T) {
 	}
 
 	placementProposal := minimalPlacement()
-	inst, err := p.LaunchInstance(context.TODO(), minimalNodeClaim(), minimalNodeClass(),
-		it, minimalImageResolve(),
+	inst, err := p.LaunchInstance(context.TODO(), minimalNodeClaim(), minimalNodeClass(), it, minimalImageResolve(),
 		minimalNetworkResolve(), nil, placementProposal)
 
 	require.NoError(t, err)
@@ -1368,8 +1415,8 @@ func TestProvider_LaunchInstance_Timeout(t *testing.T) {
 	}
 
 	t.Run("launch a bm shape timeout should return an instance without error", func(t *testing.T) {
-		inst, launchErr := p.LaunchInstance(context.TODO(), newNodeClaim(displayName1), minimalNodeClass(),
-			newInstanceType("BM.Standard1.1"), minimalImageResolve(),
+		inst, launchErr := p.LaunchInstance(context.TODO(), newNodeClaim(displayName1),
+			minimalNodeClass(), newInstanceType("BM.Standard1.1"), minimalImageResolve(),
 			minimalNetworkResolve(), nil, minimalPlacement())
 
 		require.NoError(t, launchErr)
@@ -1380,8 +1427,7 @@ func TestProvider_LaunchInstance_Timeout(t *testing.T) {
 	t.Run("launch a vm shape timeout, then retrieve volumes success with attached volume,"+
 		" should return an instance without error", func(t *testing.T) {
 		inst, launchErr := p.LaunchInstance(context.TODO(), newNodeClaim(displayName1), minimalNodeClass(),
-			newInstanceType("VM.Standard1.1"), minimalImageResolve(),
-			minimalNetworkResolve(), nil, minimalPlacement())
+			newInstanceType("VM.Standard1.1"), minimalImageResolve(), minimalNetworkResolve(), nil, minimalPlacement())
 
 		require.NoError(t, launchErr)
 		assert.NotNil(t, inst)
@@ -1391,8 +1437,7 @@ func TestProvider_LaunchInstance_Timeout(t *testing.T) {
 	t.Run("launch a vm shape timeout, then retrieve volumes failed, "+
 		"should return an instance without error", func(t *testing.T) {
 		inst, launchErr := p.LaunchInstance(context.TODO(), newNodeClaim(displayName4), minimalNodeClass(),
-			newInstanceType("VM.Standard1.1"), minimalImageResolve(),
-			minimalNetworkResolve(), nil, minimalPlacement())
+			newInstanceType("VM.Standard1.1"), minimalImageResolve(), minimalNetworkResolve(), nil, minimalPlacement())
 
 		require.NoError(t, launchErr)
 		assert.NotNil(t, inst)
@@ -1402,8 +1447,7 @@ func TestProvider_LaunchInstance_Timeout(t *testing.T) {
 	t.Run("launch a vm shape timeout, then retrieve volumes success but no volume attached, "+
 		"then try to terminate instance but failed, should return an instance without error", func(t *testing.T) {
 		inst, launchErr := p.LaunchInstance(context.TODO(), newNodeClaim(displayName3), minimalNodeClass(),
-			newInstanceType("VM.Standard1.1"), minimalImageResolve(),
-			minimalNetworkResolve(), nil, minimalPlacement())
+			newInstanceType("VM.Standard1.1"), minimalImageResolve(), minimalNetworkResolve(), nil, minimalPlacement())
 
 		require.NoError(t, launchErr)
 		assert.NotNil(t, inst)
@@ -1413,8 +1457,7 @@ func TestProvider_LaunchInstance_Timeout(t *testing.T) {
 	t.Run("launch a vm shape timeout, then retrieve volumes success but no volume attached, "+
 		"then try to terminate instance and success, should return no capacity error", func(t *testing.T) {
 		inst, launchErr := p.LaunchInstance(context.TODO(), newNodeClaim(displayName2), minimalNodeClass(),
-			newInstanceType("VM.Standard1.1"), minimalImageResolve(),
-			minimalNetworkResolve(), nil, minimalPlacement())
+			newInstanceType("VM.Standard1.1"), minimalImageResolve(), minimalNetworkResolve(), nil, minimalPlacement())
 
 		require.NotNil(t, launchErr)
 		assert.Nil(t, inst)


### PR DESCRIPTION
# Description

Fixes orphan controller instance discovery so OCI instances are only considered owned when they belong to the current Karpenter NodePool ownership context.

This change tags newly launched OCI instances with the owning NodePool UID resolved from the NodeClaim owner reference, and uses that UID during instance listing when the tag is present. This prevents the orphan controller from accidentally treating instances from another or stale NodePool with the same name as owned by the current cluster. Delete behavior continues to trust `nodeClaim.status.providerID`.

No external dependencies are required.

Fixes # 
https://github.com/oracle/karpenter-provider-oci/issues/10

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Ran focused package tests and diff hygiene checks locally.

- [x] `go test ./pkg/cloudprovider ./pkg/providers/instance`
- [x] `git diff --check origin/main...HEAD`
- Manul test
Same nodepool name in the same compartment isn't deleting each other nodes 
```
karpenter-provider-oci git:(v1.1.0) export KUBECONFIG=/Users/aribandy/work/oke/oke-kube-config/prod-karpenter-oci-npn
➜  karpenter-provider-oci git:(v1.1.0) k get nodeclaims -owide
NAME                      TYPE             CAPACITY    ZONE       NODE          READY   AGE   IMAGEID                                                                            ID                                                                                    NODEPOOL            NODECLASS        DRIFTED
nodepool-test-bk7xc       VM.Standard2.1   on-demand   PHX-AD-2   10.0.10.143   True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljsh4gjgpyc3rlijmmli3dc4h53zfzqmqzibok6ul4nj3e5wc3ygfeq   nodepool-test       nodeclass-test
nodepool-test-blvg4       VM.Standard2.1   on-demand   PHX-AD-3   10.0.10.39    True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljrh4gjgpyctelw523s36rs73l7lis6z5zhhdlb2be5g6fphzhtmo4a   nodepool-test       nodeclass-test
nodepool-test-gntdp       VM.Standard2.1   on-demand   PHX-AD-1   10.0.10.87    True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljth4gjgpyciqov4mzswk5gmn7fsmmyihq4v6mhh6h7dc6h4aqu5svq   nodepool-test       nodeclass-test
nodepool-test-new-9lprj   VM.Standard2.1   on-demand   PHX-AD-1   10.0.10.104   True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljth4gjgpycih56xtlz7xpwbyryepfr7hmkg2l5kc36jis5iawzfrta   nodepool-test-new   nodeclass-test
nodepool-test-new-gwhr2   VM.Standard2.1   on-demand   PHX-AD-1   10.0.10.59    True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljth4gjgpycxa72tlwhfnhoooutwb37lubmebv7frfwsoytpdxruopa   nodepool-test-new   nodeclass-test
nodepool-test-new-t6g8v   VM.Standard2.1   on-demand   PHX-AD-2   10.0.10.6     True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljsh4gjgpycmff4ot6ilo4mgzgc3ov6cud2tl2r7hrrqkx3drehx2qa   nodepool-test-new   nodeclass-test
➜  karpenter-provider-oci git:(v1.1.0) export KUBECONFIG=/Users/aribandy/work/oke/oke-kube-config/prod-karpenter-oci-fl
➜  karpenter-provider-oci git:(v1.1.0) k get nodeclaims -owide
NAME                      TYPE             CAPACITY    ZONE       NODE          READY   AGE   IMAGEID                                                                            ID                                                                                    NODEPOOL            NODECLASS        DRIFTED
nodepool-test-bq8dm       VM.Standard2.1   on-demand   PHX-AD-1   10.0.10.203   True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljth4gjgpyc7qx57hj6fnavqihb3rsejtq4btgsohqy3ukyvul2bpzq   nodepool-test       nodeclass-test
nodepool-test-gthjr       VM.Standard2.1   on-demand   PHX-AD-2   10.0.10.107   True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljsh4gjgpycdw6hd6j43r6ocnarcmjot72embk7ime3a5eisf7q5fpa   nodepool-test       nodeclass-test
nodepool-test-new-cbtg4   VM.Standard2.1   on-demand   PHX-AD-3   10.0.10.75    True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljrh4gjgpycg2rjyrtlbmnmmqixxp6ciy6acxflfjz7kxwxd2mab4aa   nodepool-test-new   nodeclass-test
nodepool-test-new-g797l   VM.Standard2.1   on-demand   PHX-AD-2   10.0.10.56    True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljsh4gjgpychufnm6nespn7yrmr3rukoc3jfdv3srwoyeq254cuajwa   nodepool-test-new   nodeclass-test
nodepool-test-new-tkddf   VM.Standard2.1   on-demand   PHX-AD-1   10.0.10.179   True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljth4gjgpycvyw7yqpd2kvbnlg2m3eyflaaedmb3gg54s4xiykimxnq   nodepool-test-new   nodeclass-test
nodepool-test-vknc6       VM.Standard2.1   on-demand   PHX-AD-1   10.0.10.237   True    21h   ocid1.image.oc1.phx.aaaaaaaabmzx3jzi4apjphy35hjxcgczqf7uw6jqzr5gwbczprmfqeqz3i5a   ocid1.instance.oc1.phx.anyhqljth4gjgpycujh7edqbe7trywhxz6onji46ztcbikpupgtiem2gncwa   nodepool-test       nodeclass-test
➜  karpenter-provider-oci git:(v1.1.0)
``` 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules