### PR TITLE
fix: handle cases where OCI is out of capacity

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -164,6 +164,10 @@ spec:
             - name: RATE_LIMIT_BURST_WRITE
               value: "{{ . }}"
             {{- end }}
+            {{- if not (kindIs "invalid" .Values.settings.unavailableOfferingsTTLSeconds) }}
+            - name: UNAVAILABLE_OFFERINGS_TTL_SECONDS
+              value: "{{ .Values.settings.unavailableOfferingsTTLSeconds }}"
+            {{- end }}
             {{- with .Values.settings.flexibleShapeConfigs }}
             - name: FLEXIBLE_SHAPE_CONFIGS
               value: {{ . | toJson | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -268,6 +268,13 @@ settings:
   # will be batched separately.
   batchIdleDuration: 1s
 
+  # -- How long, in seconds, an offering observed to be out of host capacity is treated as unavailable
+  # before Karpenter retries it. Lower values retry exhausted offerings sooner; higher values reduce
+  # repeated launch attempts (and OCI throttling) against capacity that is unlikely to recover quickly.
+  # Set to 0 to disable the unavailable-offerings cache entirely, in which case offerings are never
+  # marked unavailable and Karpenter does not route around capacity-exhausted offerings.
+  unavailableOfferingsTTLSeconds: 180
+
   # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
   # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features
   featureGates:

--- a/docs/reference/helm-chart.md
+++ b/docs/reference/helm-chart.md
@@ -88,6 +88,7 @@ A Helm chart for Karpenter provider OCI
 | settings.rateLimiter.disable | bool | `true` | Disable the OCI client-side rate limiter. |
 | settings.rateLimiter.qpsRead | int | `0` | Read QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
 | settings.rateLimiter.qpsWrite | int | `0` | Write QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
+| settings.unavailableOfferingsTTLSeconds | int | `180` | How long, in seconds, an offering observed to be out of host capacity is treated as unavailable before Karpenter retries it. Lower values retry exhausted offerings sooner; higher values reduce repeated launch attempts (and OCI throttling) against capacity that is unlikely to recover quickly. Set to 0 to disable the unavailable-offerings cache entirely, in which case offerings are never marked unavailable and Karpenter does not route around capacity-exhausted offerings. |
 | settings.vcnCompartmentId | string | `""` | [required] Cluster's VCN compartment OCID. |
 | strategy | object | `{"rollingUpdate":{"maxUnavailable":1}}` | Strategy for updating the pod. |
 | terminationGracePeriodSeconds | string | `nil` | Override the default termination grace period for the pod. |

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -23,6 +23,13 @@ const (
 	LongTTL = 24 * time.Hour
 	// DefaultCleanupInterval triggers cache cleanup (lazy eviction) at this interval.
 	DefaultCleanupInterval = 10 * time.Minute
+
+	// UnavailableOfferingsTTL is the default duration an offering observed to be out of host
+	// capacity is considered unavailable before Karpenter retries it. It is overridable via the
+	// --unavailable-offerings-ttl-seconds option.
+	UnavailableOfferingsTTL = 3 * time.Minute
+	// UnavailableOfferingsCleanupInterval triggers cleanup of the unavailable-offerings cache.
+	UnavailableOfferingsCleanupInterval = time.Minute
 )
 
 type LoaderFunc[T any] func(ctx context.Context, key string) (T, error)

--- a/pkg/cache/unavailableofferings.go
+++ b/pkg/cache/unavailableofferings.go
@@ -1,0 +1,131 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// UnavailableOfferings stores offerings that recently failed to launch because of host-capacity
+// exhaustion. Offerings present in the cache are treated as unavailable (Available=false) when
+// instance types are listed, so the scheduler routes around them (including spot->on-demand and
+// cross-NodePool fallback) until the entry's TTL expires.
+type UnavailableOfferings struct {
+	cache *cache.Cache
+	ttl   time.Duration
+	// disabled reports whether the feature is turned off (ttl of 0). When disabled, MarkUnavailable
+	// is a no-op and IsUnavailable always returns false, so Karpenter never routes around
+	// capacity-exhausted offerings.
+	disabled bool
+}
+
+// NewUnavailableOfferings creates the cache with the given TTL for how long an offering observed to
+// be out of host capacity stays unavailable before Karpenter retries it.
+//
+// A ttl of 0 disables the feature entirely: offerings are never recorded as unavailable and
+// IsUnavailable always returns false. A negative ttl is treated as invalid and falls back to
+// UnavailableOfferingsTTL.
+func NewUnavailableOfferings(ttl time.Duration) *UnavailableOfferings {
+	if ttl == 0 {
+		return &UnavailableOfferings{disabled: true}
+	}
+	if ttl < 0 {
+		ttl = UnavailableOfferingsTTL
+	}
+	return &UnavailableOfferings{
+		cache: cache.New(ttl, UnavailableOfferingsCleanupInterval),
+		ttl:   ttl,
+	}
+}
+
+// MarkUnavailable records the given offering as unavailable for the configured TTL. Calling it
+// again for an already-cached offering refreshes the TTL. For flexible shapes, ocpu and memoryInGbs
+// scope the entry to a specific CPU/memory configuration so that a failure for one config does not
+// suppress every other config of the same shape; they are nil for fixed shapes.
+//
+// compartment scopes the entry to a single compartment. It should be set for compartment-scoped
+// failures (OCI QuotaExceeded, an administrator-defined quota for a specific compartment and
+// resource) so the offering is not suppressed for NodeClasses launching into other compartments.
+// It must be empty for failures that apply regardless of compartment (host-capacity exhaustion and
+// tenancy-scoped LimitExceeded service limits).
+func (u *UnavailableOfferings) MarkUnavailable(ctx context.Context, shape string, ocpu, memoryInGbs *float32,
+	zone, capacityType, compartment string) {
+	if u.disabled {
+		return
+	}
+	log.FromContext(ctx).WithValues(
+		"shape", shape,
+		"ocpu", flexResourceLogValue(ocpu),
+		"memory-in-gbs", flexResourceLogValue(memoryInGbs),
+		"zone", zone,
+		"capacity-type", capacityType,
+		"compartment", compartmentLogValue(compartment),
+		"ttl", u.ttl,
+	).Info("marking offering as unavailable")
+	u.cache.SetDefault(u.key(shape, ocpu, memoryInGbs, zone, capacityType, compartment), struct{}{})
+}
+
+// IsUnavailable returns true if the offering is currently cached as unavailable for the given
+// compartment scope. Pass an empty compartment to check tenancy-wide entries (host capacity /
+// LimitExceeded); pass the target compartment to check compartment-scoped entries (QuotaExceeded).
+func (u *UnavailableOfferings) IsUnavailable(shape string, ocpu, memoryInGbs *float32,
+	zone, capacityType, compartment string) bool {
+	if u.disabled {
+		return false
+	}
+	_, found := u.cache.Get(u.key(shape, ocpu, memoryInGbs, zone, capacityType, compartment))
+	return found
+}
+
+func (u *UnavailableOfferings) Flush() {
+	if u.disabled {
+		return
+	}
+	u.cache.Flush()
+}
+
+// key returns the cache key for an offering. Format:
+// <capacityType>:<shape>:<ocpu>:<memoryInGbs>:<zone>:<compartment>. The ocpu and memoryInGbs fields
+// distinguish flexible-shape CPU/memory configurations and are empty for fixed shapes. compartment
+// is empty for tenancy-wide entries and set for compartment-scoped (QuotaExceeded) entries.
+func (u *UnavailableOfferings) key(shape string, ocpu, memoryInGbs *float32,
+	zone, capacityType, compartment string) string {
+	return fmt.Sprintf("%s:%s:%s:%s:%s:%s", capacityType, shape,
+		flexResourceKeyValue(ocpu), flexResourceKeyValue(memoryInGbs), zone, compartment)
+}
+
+// flexResourceKeyValue renders a flexible-shape resource quantity for use in the cache key,
+// returning an empty string when the quantity is unset (fixed shapes).
+func flexResourceKeyValue(v *float32) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatFloat(float64(*v), 'f', -1, 32)
+}
+
+func flexResourceLogValue(v *float32) string {
+	if v == nil {
+		return "<nil>"
+	}
+	return flexResourceKeyValue(v)
+}
+
+// compartmentLogValue renders the compartment scope for logging, distinguishing tenancy-wide
+// entries (empty compartment) from compartment-scoped entries.
+func compartmentLogValue(compartment string) string {
+	if compartment == "" {
+		return "<tenancy-wide>"
+	}
+	return compartment
+}

--- a/pkg/cache/unavailableofferings_test.go
+++ b/pkg/cache/unavailableofferings_test.go
@@ -1,0 +1,150 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnavailableOfferings_MarkAndIsUnavailable(t *testing.T) {
+	ctx := context.Background()
+	u := NewUnavailableOfferings(UnavailableOfferingsTTL)
+
+	assert.False(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", ""))
+
+	u.MarkUnavailable(ctx, "VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", "")
+	assert.True(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", ""))
+
+	// distinct capacity type, zone and shape are unaffected.
+	assert.False(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-1", "on-demand", ""))
+	assert.False(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-2", "spot", ""))
+	assert.False(t, u.IsUnavailable("VM.Standard.E4.Flex", nil, nil, "AD-1", "spot", ""))
+}
+
+func TestUnavailableOfferings_ScopedByFlexConfig(t *testing.T) {
+	ctx := context.Background()
+	u := NewUnavailableOfferings(UnavailableOfferingsTTL)
+
+	const (
+		shape = "VM.Standard.E4.Flex"
+		zone  = "AD-1"
+		capOD = "on-demand"
+	)
+
+	// Mark only the 2 OCPU / 16 GB config of a flexible shape as unavailable.
+	u.MarkUnavailable(ctx, shape, lo.ToPtr(float32(2)), lo.ToPtr(float32(16)), zone, capOD, "")
+	assert.True(t, u.IsUnavailable(shape, lo.ToPtr(float32(2)), lo.ToPtr(float32(16)), zone, capOD, ""))
+
+	// Other CPU/memory configurations of the same shape/zone/capacity-type stay available.
+	assert.False(t, u.IsUnavailable(shape, lo.ToPtr(float32(4)), lo.ToPtr(float32(16)), zone, capOD, ""),
+		"a different ocpu config must not be suppressed")
+	assert.False(t, u.IsUnavailable(shape, lo.ToPtr(float32(2)), lo.ToPtr(float32(32)), zone, capOD, ""),
+		"a different memory config must not be suppressed")
+	// A fixed-shape (nil config) lookup for the same shape is also unaffected.
+	assert.False(t, u.IsUnavailable(shape, nil, nil, zone, capOD, ""),
+		"a nil (fixed) config must not match a flex-config entry")
+}
+
+func TestUnavailableOfferings_ScopedByCompartment(t *testing.T) {
+	ctx := context.Background()
+	u := NewUnavailableOfferings(UnavailableOfferingsTTL)
+
+	const (
+		shape        = "VM.Standard.E4.Flex"
+		zone         = "AD-1"
+		capOD        = "on-demand"
+		compartmentA = "ocid1.compartment.oc1..aaaa"
+		compartmentB = "ocid1.compartment.oc1..bbbb"
+	)
+
+	// A compartment-scoped (QuotaExceeded) entry only suppresses that compartment.
+	u.MarkUnavailable(ctx, shape, nil, nil, zone, capOD, compartmentA)
+	assert.True(t, u.IsUnavailable(shape, nil, nil, zone, capOD, compartmentA))
+	assert.False(t, u.IsUnavailable(shape, nil, nil, zone, capOD, compartmentB),
+		"another compartment must not be suppressed by a compartment-scoped entry")
+	assert.False(t, u.IsUnavailable(shape, nil, nil, zone, capOD, ""),
+		"the tenancy-wide scope must not be suppressed by a compartment-scoped entry")
+
+	// A tenancy-wide (host capacity / LimitExceeded) entry is independent of compartment scope.
+	u.MarkUnavailable(ctx, shape, nil, nil, zone, "spot", "")
+	assert.True(t, u.IsUnavailable(shape, nil, nil, zone, "spot", ""))
+	assert.False(t, u.IsUnavailable(shape, nil, nil, zone, "spot", compartmentA),
+		"a compartment-scoped lookup must not match a tenancy-wide entry")
+}
+
+func TestUnavailableOfferings_Flush(t *testing.T) {
+	ctx := context.Background()
+	u := NewUnavailableOfferings(UnavailableOfferingsTTL)
+
+	u.MarkUnavailable(ctx, "VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", "")
+	u.MarkUnavailable(ctx, "VM.Standard.E5.Flex", nil, nil, "AD-2", "on-demand", "")
+	assert.True(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", ""))
+	assert.True(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-2", "on-demand", ""))
+
+	u.Flush()
+	assert.False(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", ""))
+	assert.False(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-2", "on-demand", ""))
+}
+
+func TestUnavailableOfferings_TTLExpiry(t *testing.T) {
+	ctx := context.Background()
+	// a short, configurable TTL is honored by MarkUnavailable so entries expire quickly.
+	u := NewUnavailableOfferings(20 * time.Millisecond)
+
+	u.MarkUnavailable(ctx, "VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", "")
+	assert.True(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", ""))
+
+	time.Sleep(40 * time.Millisecond)
+	assert.False(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", ""))
+}
+
+func TestUnavailableOfferings_DefaultsTTLWhenNegative(t *testing.T) {
+	// A negative ttl is invalid and falls back to the default; an explicit ttl is honored as-is.
+	assert.Equal(t, UnavailableOfferingsTTL, NewUnavailableOfferings(-time.Second).ttl)
+	assert.False(t, NewUnavailableOfferings(-time.Second).disabled)
+	assert.Equal(t, time.Minute, NewUnavailableOfferings(time.Minute).ttl)
+	assert.False(t, NewUnavailableOfferings(time.Minute).disabled)
+}
+
+// A ttl of 0 disables the cache: offerings are never recorded and IsUnavailable always reports
+// available, so Karpenter never routes around capacity-exhausted offerings.
+func TestUnavailableOfferings_DisabledWhenZeroTTL(t *testing.T) {
+	ctx := context.Background()
+	u := NewUnavailableOfferings(0)
+
+	assert.True(t, u.disabled)
+
+	u.MarkUnavailable(ctx, "VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", "")
+	assert.False(t, u.IsUnavailable("VM.Standard.E5.Flex", nil, nil, "AD-1", "spot", ""),
+		"a disabled cache must never report an offering as unavailable")
+
+	// Flush must be a safe no-op on a disabled cache.
+	assert.NotPanics(t, u.Flush)
+}
+
+func TestUnavailableOfferings_Key(t *testing.T) {
+	u := NewUnavailableOfferings(UnavailableOfferingsTTL)
+
+	// Fixed shapes render empty ocpu/memory segments; tenancy-wide entries have an empty
+	// trailing compartment segment.
+	assert.Equal(t, "on-demand:VM.Standard.E3.8:::AD-1:", u.key("VM.Standard.E3.8", nil, nil, "AD-1", "on-demand", ""))
+	// Flexible shapes include the CPU/memory configuration.
+	assert.Equal(t, "spot:VM.Standard.E4.Flex:2:16:AD-1:",
+		u.key("VM.Standard.E4.Flex", lo.ToPtr(float32(2)), lo.ToPtr(float32(16)), "AD-1", "spot", ""))
+	// Fractional values are preserved without trailing zeros.
+	assert.Equal(t, "on-demand:VM.Standard.E4.Flex:1.5:24:AD-2:",
+		u.key("VM.Standard.E4.Flex", lo.ToPtr(float32(1.5)), lo.ToPtr(float32(24)), "AD-2", "on-demand", ""))
+	// Compartment-scoped entries include the compartment in the trailing segment.
+	assert.Equal(t, "on-demand:VM.Standard.E3.8:::AD-1:ocid1.compartment.oc1..aaaa",
+		u.key("VM.Standard.E3.8", nil, nil, "AD-1", "on-demand", "ocid1.compartment.oc1..aaaa"))
+}

--- a/pkg/cloudprovider/cloud_provider.go
+++ b/pkg/cloudprovider/cloud_provider.go
@@ -172,7 +172,11 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *corev1.NodeClaim)
 
 	var inst *instance.InstanceInfo
 	var selectedInstanceType *instancetype.OciInstanceType
-	var capacityErr error
+	// track whether any launch attempt failed because of a skippable capacity exhaustion
+	// (host-capacity shortage or service-limit/compartment-quota) so we can surface an
+	// InsufficientCapacityError (which triggers NodeClaim deletion + reschedule) once all
+	// instance types are consumed.
+	var skipErr error
 
 	// try launch until all instance types are consumed.
 	for _, instanceType := range instanceTypes {
@@ -201,8 +205,11 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *corev1.NodeClaim)
 		if err != nil {
 			lg.Error(err, "cannot launch instance")
 			// TODO in capacity reservation case, what error will we get if there is no capacity?
-			if instance.IsNoCapacityError(err) {
-				capacityErr = err
+			// Host-capacity shortage and service-limit/compartment-quota failures are skippable:
+			// move on to the next shape and remember the error so we can surface an
+			// InsufficientCapacityError if every candidate shape is exhausted.
+			if instance.IsSkippableLaunchError(err) {
+				skipErr = err
 				continue
 			}
 			return nil, cloudprovider.NewCreateError(fmt.Errorf("launch instance failure, %w", err),
@@ -215,13 +222,18 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *corev1.NodeClaim)
 	}
 
 	if inst == nil {
+		// No instance type launched and at least one launch attempt failed due to a skippable
+		// capacity exhaustion (host-capacity shortage or service-limit/compartment-quota;
+		// non-skippable launch errors return earlier). Surface an InsufficientCapacityError so
+		// core Karpenter deletes the NodeClaim and reschedules, enabling fallback to other
+		// offerings / capacity types / NodePools.
+		if skipErr != nil {
+			errMsg := "all instance types exhausted due to insufficient capacity"
+			lg.Error(skipErr, errMsg)
+			return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("%s, %w", errMsg, skipErr))
+		}
 		errMsg := "cannot create node after trying all instance types"
 		finalErr := errors.New(errMsg)
-		if capacityErr != nil {
-			finalErr = fmt.Errorf("%s, %w", errMsg, capacityErr)
-			lg.Error(finalErr, "")
-			return nil, cloudprovider.NewInsufficientCapacityError(finalErr)
-		}
 		lg.Error(finalErr, "")
 		return nil, cloudprovider.NewCreateError(finalErr, "LaunchInstanceFailed", errMsg)
 	}

--- a/pkg/cloudprovider/cloud_provider_test.go
+++ b/pkg/cloudprovider/cloud_provider_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
+	ocicache "github.com/oracle/karpenter-provider-oci/pkg/cache"
 	"github.com/oracle/karpenter-provider-oci/pkg/controllers/nodeclasses"
 	"github.com/oracle/karpenter-provider-oci/pkg/fakes"
 	npnv1beta1 "github.com/oracle/karpenter-provider-oci/pkg/npn/apis/v1beta1"
@@ -41,11 +42,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/provisioning"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/events"
+	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+	coretest "sigs.k8s.io/karpenter/pkg/test"
 	. "sigs.k8s.io/karpenter/pkg/test/expectations"
 )
 
@@ -592,6 +600,52 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			Expect(created.Labels[corev1.LabelInstanceTypeStable]).To(Equal("shape-b"))
 		})
 
+		It("should try the next shape config when the first is out of host capacity "+
+			"(single shape, multiple shape configs)", func() {
+			// A NodePool pinned to a single shape paired with a NodeClass that declares multiple
+			// shape configs resolves to multiple instance types that share the same Shape but differ
+			// by OCPU/memory. When the first (cheaper) shape config is out of host capacity, the
+			// launch loop must move on and attempt the next shape config rather than failing.
+			const shape = "VM.Standard.E5.Flex"
+			smallConfig := testInstanceType(shape, 10)
+			smallConfig.Ocpu = lo.ToPtr(float32(2))
+			largeConfig := testInstanceType(shape, 20)
+			largeConfig.Ocpu = lo.ToPtr(float32(4))
+
+			launchCount := 0
+			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+				kubeClient:    kubeClient,
+				instanceTypes: []*instancetype.OciInstanceType{smallConfig, largeConfig},
+				imageProvider: &FakeImageProvider{
+					ResolveImageForShapeFn: func(_ context.Context, _ *v1beta1.ImageConfig,
+						_ string) (*image.ImageResolveResult, error) {
+						return imageResult, nil
+					},
+				},
+				instanceProvider: &FakeInstanceProvider{
+					LaunchInstanceFn: func(_ context.Context, nc *v1.NodeClaim, _ *v1beta1.OCINodeClass,
+						it *instancetype.OciInstanceType, _ *image.ImageResolveResult, _ *network.NetworkResolveResult,
+						_ *kms.KmsKeyResolveResult, _ *placement.Proposal) (*instance.InstanceInfo, error) {
+						launchCount++
+						// Only the smaller shape config is out of host capacity.
+						if it.Ocpu != nil && *it.Ocpu == float32(2) {
+							return nil, instance.NoCapacityError{}
+						}
+						return &instance.InstanceInfo{
+							Instance: testInstanceWithShape(it.Shape, nc.Labels[v1.NodePoolLabelKey]),
+						}, nil
+					},
+				},
+			})
+
+			created, err := cp.Create(context.Background(), nodeClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(created).ToNot(BeNil())
+			// Both shape configs were attempted: the first failed with OOHC, the second succeeded.
+			Expect(launchCount).To(Equal(2))
+			Expect(created.Labels[corev1.LabelInstanceTypeStable]).To(Equal(shape))
+		})
+
 		It("should retry on no capacity and ignore NPN apply failures", func() {
 			launchCount := 0
 			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
@@ -680,6 +734,88 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			var createErr *cloudprovider.CreateError
 			Expect(errors.As(err, &createErr)).To(BeTrue())
 			Expect(createErr.ConditionReason).To(Equal("LaunchInstanceFailed"))
+		})
+
+		It("should return insufficient capacity when all instance types are out of host capacity", func() {
+			launchCount := 0
+			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+				kubeClient:    kubeClient,
+				instanceTypes: []*instancetype.OciInstanceType{instanceA, instanceB},
+				imageProvider: &FakeImageProvider{
+					ResolveImageForShapeFn: func(_ context.Context, _ *v1beta1.ImageConfig,
+						_ string) (*image.ImageResolveResult, error) {
+						return imageResult, nil
+					},
+				},
+				instanceProvider: &FakeInstanceProvider{
+					LaunchInstanceFn: func(_ context.Context, _ *v1.NodeClaim, _ *v1beta1.OCINodeClass,
+						_ *instancetype.OciInstanceType, _ *image.ImageResolveResult, _ *network.NetworkResolveResult,
+						_ *kms.KmsKeyResolveResult, _ *placement.Proposal) (*instance.InstanceInfo, error) {
+						launchCount++
+						return nil, instance.NoCapacityError{}
+					},
+				},
+			})
+
+			_, err := cp.Create(context.Background(), nodeClaim)
+			Expect(cloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
+			Expect(launchCount).To(Equal(2))
+		})
+
+		It("should return insufficient capacity when all instance types hit a service limit", func() {
+			launchCount := 0
+			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+				kubeClient:    kubeClient,
+				instanceTypes: []*instancetype.OciInstanceType{instanceA, instanceB},
+				imageProvider: &FakeImageProvider{
+					ResolveImageForShapeFn: func(_ context.Context, _ *v1beta1.ImageConfig,
+						_ string) (*image.ImageResolveResult, error) {
+						return imageResult, nil
+					},
+				},
+				instanceProvider: &FakeInstanceProvider{
+					LaunchInstanceFn: func(_ context.Context, _ *v1.NodeClaim, _ *v1beta1.OCINodeClass,
+						_ *instancetype.OciInstanceType, _ *image.ImageResolveResult, _ *network.NetworkResolveResult,
+						_ *kms.KmsKeyResolveResult, _ *placement.Proposal) (*instance.InstanceInfo, error) {
+						launchCount++
+						return nil, fakeServiceError{statusCode: 400, code: "LimitExceeded", message: "service limit exceeded"}
+					},
+				},
+			})
+
+			_, err := cp.Create(context.Background(), nodeClaim)
+			Expect(cloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
+			Expect(launchCount).To(Equal(2))
+		})
+
+		It("should fall back to the next shape when one shape hits a service limit", func() {
+			launchCount := 0
+			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+				kubeClient:    kubeClient,
+				instanceTypes: []*instancetype.OciInstanceType{instanceA, instanceB},
+				imageProvider: &FakeImageProvider{
+					ResolveImageForShapeFn: func(_ context.Context, _ *v1beta1.ImageConfig,
+						_ string) (*image.ImageResolveResult, error) {
+						return imageResult, nil
+					},
+				},
+				instanceProvider: &FakeInstanceProvider{
+					LaunchInstanceFn: func(_ context.Context, _ *v1.NodeClaim, _ *v1beta1.OCINodeClass,
+						it *instancetype.OciInstanceType, _ *image.ImageResolveResult, _ *network.NetworkResolveResult,
+						_ *kms.KmsKeyResolveResult, _ *placement.Proposal) (*instance.InstanceInfo, error) {
+						launchCount++
+						if launchCount == 1 {
+							return nil, fakeServiceError{statusCode: 400, code: "LimitExceeded", message: "service limit exceeded"}
+						}
+						return &instance.InstanceInfo{Instance: testInstanceWithShape(it.Shape, "pool-a")}, nil
+					},
+				},
+			})
+
+			created, err := cp.Create(context.Background(), nodeClaim)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(created.Labels[corev1.LabelInstanceTypeStable]).To(Equal("shape-b"))
+			Expect(launchCount).To(Equal(2))
 		})
 	})
 
@@ -945,6 +1081,43 @@ func testInstanceType(shape string, price float64) *instancetype.OciInstanceType
 	}
 }
 
+// testFlexConfigInstanceType builds a flexible-shape instance type for a specific CPU/memory
+// configuration. All configs of a shape share the same Shape but differ by Name (the instance-type
+// label) and by their Ocpu/MemoryInGbs, mirroring how listInstanceTypesForFlexShape enumerates flex
+// configs in production.
+func testFlexConfigInstanceType(shape, name string, ocpu, memory float32, price float64) *instancetype.OciInstanceType {
+	o := ocpu
+	m := memory
+	return &instancetype.OciInstanceType{
+		InstanceType: cloudprovider.InstanceType{
+			Name: name,
+			Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, name),
+			),
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewMilliQuantity(int64(ocpu*1000), resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(int64(memory)*1024*1024*1024, resource.BinarySI),
+				corev1.ResourcePods:   *resource.NewQuantity(110, resource.DecimalSI),
+			},
+			Overhead: &cloudprovider.InstanceTypeOverhead{},
+			Offerings: []*cloudprovider.Offering{{
+				Requirements: scheduling.NewRequirements(
+					scheduling.NewRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, name),
+					scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, v1.CapacityTypeOnDemand),
+					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "PHX-AD-1"),
+				),
+				Price:               price,
+				Available:           true,
+				ReservationCapacity: 1,
+			}},
+		},
+		Shape:              shape,
+		SupportShapeConfig: true,
+		Ocpu:               &o,
+		MemoryInGbs:        &m,
+	}
+}
+
 func testImageResolveResult(imageID string) *image.ImageResolveResult {
 	return &image.ImageResolveResult{
 		Images: []*ocicore.Image{{
@@ -986,3 +1159,476 @@ func (f fakeServiceError) GetOpcRequestID() string { return "req-id" }
 
 var _ common.ServiceError = fakeServiceError{}
 var _ error = fakeServiceError{}
+
+// These tests drive Karpenter core's real scheduler/provisioner against the OCI CloudProvider to
+// verify cross-NodePool fallback when one NodePool's only offering goes out of host capacity.
+//
+// The unavailable-offerings cache feeds offering availability into the instance-type provider
+// (production wiring is unit-tested in pkg/providers/instancetype). Here we exercise the end-to-end
+// behaviour: once an offering is marked unavailable, GetInstanceTypes reports it as unavailable and
+// core's scheduler routes new capacity to the other NodePool.
+var _ = Describe("CloudProvider NodePool Fallback", func() {
+	const zone = "PHX-AD-1"
+
+	var (
+		preferredShape     string
+		fallbackShape      string
+		preferredClass     string
+		fallbackClass      string
+		unavailable        *ocicache.UnavailableOfferings
+		instanceProvider   *FakeInstanceProvider
+		cp                 *CloudProvider
+		cluster            *state.Cluster
+		prov               *provisioning.Provisioner
+		provCtx            context.Context
+		preferredNodeClass *v1beta1.OCINodeClass
+		fallbackNodeClass  *v1beta1.OCINodeClass
+		preferredPool      *v1.NodePool
+		fallbackPool       *v1.NodePool
+		smallPodResources  corev1.ResourceRequirements
+	)
+
+	BeforeEach(func() {
+		preferredShape = uniqueName("shape-preferred")
+		fallbackShape = uniqueName("shape-fallback")
+		unavailable = ocicache.NewUnavailableOfferings(ocicache.UnavailableOfferingsTTL)
+
+		preferredNodeClass = testReadyNodeClass(uniqueName("preferred"))
+		fallbackNodeClass = testReadyNodeClass(uniqueName("fallback"))
+		preferredClass = preferredNodeClass.Name
+		fallbackClass = fallbackNodeClass.Name
+
+		// Instance types are resolved per-NodeClass and have their on-demand offering gated by the
+		// shared unavailable-offerings cache, mirroring the production setOfferings behaviour.
+		instanceTypeProvider := &FakeInstanceTypeProvider{
+			ListFn: func(_ context.Context, nodeClass *v1beta1.OCINodeClass,
+				_ []corev1.Taint) ([]*instancetype.OciInstanceType, error) {
+				var shape string
+				switch nodeClass.Name {
+				case preferredClass:
+					shape = preferredShape
+				case fallbackClass:
+					shape = fallbackShape
+				default:
+					return nil, nil
+				}
+				it := fallbackTestInstanceType(shape, 10)
+				for _, o := range it.Offerings {
+					if unavailable.IsUnavailable(shape, it.Ocpu, it.MemoryInGbs, o.Zone(), o.CapacityType(), "") {
+						o.Available = false
+					}
+				}
+				return []*instancetype.OciInstanceType{it}, nil
+			},
+		}
+
+		instanceProvider = &FakeInstanceProvider{
+			LaunchInstanceFn: func(_ context.Context, nc *v1.NodeClaim, _ *v1beta1.OCINodeClass,
+				it *instancetype.OciInstanceType, _ *image.ImageResolveResult, _ *network.NetworkResolveResult,
+				_ *kms.KmsKeyResolveResult, _ *placement.Proposal) (*instance.InstanceInfo, error) {
+				return &instance.InstanceInfo{
+					Instance: testInstanceWithShape(it.Shape, nc.Labels[v1.NodePoolLabelKey]),
+				}, nil
+			},
+		}
+
+		cp = newUnitTestCloudProvider(unitTestCloudProviderOptions{
+			kubeClient:           k8sClient,
+			instanceTypeProvider: instanceTypeProvider,
+			instanceProvider:     instanceProvider,
+		})
+
+		clk := clock.RealClock{}
+		recorder := events.NewRecorder(&record.FakeRecorder{})
+		cluster = state.NewCluster(clk, k8sClient, cp)
+		prov = provisioning.NewProvisioner(k8sClient, recorder, cp, cluster, clk)
+		provCtx = coreoptions.ToContext(ctx, coretest.Options())
+
+		// Preferred pool has the higher weight, so the scheduler always tries it first.
+		preferredPool = fallbackTestNodePool(uniqueName("preferred-pool"), preferredClass, 100)
+		fallbackPool = fallbackTestNodePool(uniqueName("fallback-pool"), fallbackClass, 10)
+
+		ExpectApplied(provCtx, k8sClient, preferredNodeClass, fallbackNodeClass, preferredPool, fallbackPool)
+
+		// Sized so that only one such pod fits per node, forcing a fresh node per pod.
+		smallPodResources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1500m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		}
+	})
+
+	AfterEach(func() {
+		// ExpectCleanedUp references a TestNodeClass CRD that is not registered in this envtest, so we
+		// delete the objects this suite created directly. Unique names keep specs isolated.
+		ExpectDeleted(provCtx, k8sClient, preferredPool, fallbackPool, preferredNodeClass, fallbackNodeClass)
+	})
+
+	It("schedules to the preferred NodePool while its offering is available", func() {
+		pod := coretest.UnschedulablePod(coretest.PodOptions{ResourceRequirements: smallPodResources})
+		bindings := ExpectProvisioned(provCtx, k8sClient, cluster, cp, prov, pod)
+
+		binding := bindings.Get(pod)
+		Expect(binding).ToNot(BeNil())
+		Expect(binding.NodeClaim).ToNot(BeNil())
+		Expect(binding.NodeClaim.Labels[v1.NodePoolLabelKey]).To(Equal(preferredPool.Name))
+		Expect(binding.NodeClaim.Labels[corev1.LabelInstanceTypeStable]).To(Equal(preferredShape))
+	})
+
+	It("falls back to another NodePool once the preferred offering is out of capacity", func() {
+		// First pod lands on the preferred pool.
+		pod1 := coretest.UnschedulablePod(coretest.PodOptions{ResourceRequirements: smallPodResources})
+		bindings := ExpectProvisioned(provCtx, k8sClient, cluster, cp, prov, pod1)
+		binding1 := bindings.Get(pod1)
+		Expect(binding1).ToNot(BeNil())
+		Expect(binding1.NodeClaim).ToNot(BeNil())
+		Expect(binding1.NodeClaim.Labels[v1.NodePoolLabelKey]).To(Equal(preferredPool.Name))
+
+		// Preferred pool's on-demand offering (for its resolved CPU/memory config) goes out of host
+		// capacity.
+		preferredIT := fallbackTestInstanceType(preferredShape, 10)
+		unavailable.MarkUnavailable(provCtx, preferredShape, preferredIT.Ocpu, preferredIT.MemoryInGbs,
+			zone, v1.CapacityTypeOnDemand, "")
+
+		// Next pod cannot reuse the preferred node and the preferred offering is unavailable, so the
+		// scheduler must fall back to the other NodePool.
+		pod2 := coretest.UnschedulablePod(coretest.PodOptions{ResourceRequirements: smallPodResources})
+		bindings = ExpectProvisioned(provCtx, k8sClient, cluster, cp, prov, pod2)
+		binding2 := bindings.Get(pod2)
+		Expect(binding2).ToNot(BeNil())
+		Expect(binding2.NodeClaim).ToNot(BeNil())
+		Expect(binding2.NodeClaim.Labels[v1.NodePoolLabelKey]).To(Equal(fallbackPool.Name))
+		Expect(binding2.NodeClaim.Labels[corev1.LabelInstanceTypeStable]).To(Equal(fallbackShape))
+	})
+
+	It("falls back to another NodePool when the preferred pool's launch hits a service limit", func() {
+		// The preferred shape's launch fails with a service-limit (LimitExceeded) error. We emulate
+		// the production LaunchInstance defer by marking the offering unavailable on that error; the
+		// FakeInstanceProvider does not run the real defer. CloudProvider.Create classifies this as an
+		// InsufficientCapacityError, so no node is created this round.
+		instanceProvider.LaunchInstanceFn = func(_ context.Context, nc *v1.NodeClaim, _ *v1beta1.OCINodeClass,
+			it *instancetype.OciInstanceType, _ *image.ImageResolveResult, _ *network.NetworkResolveResult,
+			_ *kms.KmsKeyResolveResult, _ *placement.Proposal) (*instance.InstanceInfo, error) {
+			if it.Shape == preferredShape {
+				unavailable.MarkUnavailable(provCtx, preferredShape, it.Ocpu, it.MemoryInGbs,
+					zone, v1.CapacityTypeOnDemand, "")
+				return nil, fakeServiceError{statusCode: 400, code: "LimitExceeded", message: "service limit exceeded"}
+			}
+			return &instance.InstanceInfo{
+				Instance: testInstanceWithShape(it.Shape, nc.Labels[v1.NodePoolLabelKey]),
+			}, nil
+		}
+
+		// Round 1: the pod schedules onto the higher-weighted preferred pool (its offering is still
+		// available at schedule time), but the launch hits the service limit, so no binding is made.
+		pod := coretest.UnschedulablePod(coretest.PodOptions{ResourceRequirements: smallPodResources})
+		bindings := ExpectProvisioned(provCtx, k8sClient, cluster, cp, prov, pod)
+		Expect(bindings.Get(pod)).To(BeNil())
+
+		// Core's NodeClaim lifecycle deletes the NodeClaim on InsufficientCapacityError; emulate that
+		// so the failed NodeClaim is not counted as in-flight capacity on the next scheduling round.
+		for _, nc := range ExpectNodeClaims(provCtx, k8sClient) {
+			ExpectDeleted(provCtx, k8sClient, nc)
+			cluster.DeleteNodeClaim(nc.Name)
+		}
+
+		// Round 2: the preferred offering is now cached as unavailable, so the scheduler falls back to
+		// the other NodePool.
+		bindings = ExpectProvisioned(provCtx, k8sClient, cluster, cp, prov, pod)
+		binding := bindings.Get(pod)
+		Expect(binding).ToNot(BeNil())
+		Expect(binding.NodeClaim).ToNot(BeNil())
+		Expect(binding.NodeClaim.Labels[v1.NodePoolLabelKey]).To(Equal(fallbackPool.Name))
+		Expect(binding.NodeClaim.Labels[corev1.LabelInstanceTypeStable]).To(Equal(fallbackShape))
+	})
+})
+
+// Flexible shapes expose multiple CPU/memory configs that share a Shape but differ by
+// instance-type name. This suite verifies end-to-end that marking one config's offering unavailable
+// only routes the scheduler away from that config, leaving the shape's other configs schedulable.
+var _ = Describe("CloudProvider Flex Config Scoping", func() {
+	const zone = "PHX-AD-1"
+
+	var (
+		shape             string
+		smallConfig       string
+		largeConfig       string
+		nodeClass         *v1beta1.OCINodeClass
+		unavailable       *ocicache.UnavailableOfferings
+		cp                *CloudProvider
+		cluster           *state.Cluster
+		prov              *provisioning.Provisioner
+		provCtx           context.Context
+		pool              *v1.NodePool
+		smallPodResources corev1.ResourceRequirements
+	)
+
+	BeforeEach(func() {
+		shape = uniqueName("shape-flex")
+		smallConfig = shape + ".2o.16g"
+		largeConfig = shape + ".4o.16g"
+		unavailable = ocicache.NewUnavailableOfferings(ocicache.UnavailableOfferingsTTL)
+
+		nodeClass = testReadyNodeClass(uniqueName("flex"))
+
+		// Both configs of the shape are gated on the shared unavailable-offerings cache scoped by
+		// their own CPU/memory, mirroring production setOfferings.
+		instanceTypeProvider := &FakeInstanceTypeProvider{
+			ListFn: func(_ context.Context, nc *v1beta1.OCINodeClass,
+				_ []corev1.Taint) ([]*instancetype.OciInstanceType, error) {
+				if nc.Name != nodeClass.Name {
+					return nil, nil
+				}
+				// small config is cheaper, so the scheduler prefers it while it is available.
+				its := []*instancetype.OciInstanceType{
+					testFlexConfigInstanceType(shape, smallConfig, 2, 16, 1),
+					testFlexConfigInstanceType(shape, largeConfig, 4, 16, 2),
+				}
+				for _, it := range its {
+					for _, o := range it.Offerings {
+						if unavailable.IsUnavailable(it.Shape, it.Ocpu, it.MemoryInGbs, o.Zone(), o.CapacityType(), "") {
+							o.Available = false
+						}
+					}
+				}
+				return its, nil
+			},
+		}
+
+		instanceProvider := &FakeInstanceProvider{
+			LaunchInstanceFn: func(_ context.Context, nc *v1.NodeClaim, _ *v1beta1.OCINodeClass,
+				it *instancetype.OciInstanceType, _ *image.ImageResolveResult, _ *network.NetworkResolveResult,
+				_ *kms.KmsKeyResolveResult, _ *placement.Proposal) (*instance.InstanceInfo, error) {
+				return &instance.InstanceInfo{
+					Instance: testInstanceWithShape(it.Shape, nc.Labels[v1.NodePoolLabelKey]),
+				}, nil
+			},
+		}
+
+		cp = newUnitTestCloudProvider(unitTestCloudProviderOptions{
+			kubeClient:           k8sClient,
+			instanceTypeProvider: instanceTypeProvider,
+			instanceProvider:     instanceProvider,
+		})
+
+		clk := clock.RealClock{}
+		recorder := events.NewRecorder(&record.FakeRecorder{})
+		cluster = state.NewCluster(clk, k8sClient, cp)
+		prov = provisioning.NewProvisioner(k8sClient, recorder, cp, cluster, clk)
+		provCtx = coreoptions.ToContext(ctx, coretest.Options())
+
+		pool = fallbackTestNodePool(uniqueName("flex-pool"), nodeClass.Name, 100)
+		ExpectApplied(provCtx, k8sClient, nodeClass, pool)
+
+		smallPodResources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1500m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ExpectDeleted(provCtx, k8sClient, pool, nodeClass)
+	})
+
+	It("keeps other CPU/memory configs of a shape schedulable when one config is unavailable", func() {
+		// The cheaper small config is preferred while available.
+		pod1 := coretest.UnschedulablePod(coretest.PodOptions{ResourceRequirements: smallPodResources})
+		bindings := ExpectProvisioned(provCtx, k8sClient, cluster, cp, prov, pod1)
+		binding1 := bindings.Get(pod1)
+		Expect(binding1).ToNot(BeNil())
+		Expect(binding1.NodeClaim).ToNot(BeNil())
+		Expect(binding1.NodeClaim.Labels[corev1.LabelInstanceTypeStable]).To(Equal(smallConfig))
+
+		// Mark ONLY the small (2 OCPU / 16 GB) config's on-demand offering out of host capacity.
+		unavailable.MarkUnavailable(provCtx, shape, lo.ToPtr(float32(2)), lo.ToPtr(float32(16)),
+			zone, v1.CapacityTypeOnDemand, "")
+
+		// The next pod cannot use the small config, but the shape's large config is still available,
+		// so scheduling stays on the same shape rather than being globally suppressed.
+		pod2 := coretest.UnschedulablePod(coretest.PodOptions{ResourceRequirements: smallPodResources})
+		bindings = ExpectProvisioned(provCtx, k8sClient, cluster, cp, prov, pod2)
+		binding2 := bindings.Get(pod2)
+		Expect(binding2).ToNot(BeNil())
+		Expect(binding2.NodeClaim).ToNot(BeNil())
+		Expect(binding2.NodeClaim.Labels[corev1.LabelInstanceTypeStable]).To(Equal(largeConfig))
+	})
+})
+
+// A QuotaExceeded launch failure is an administrator-defined quota for a specific compartment, so it
+// must only suppress the offering for NodeClasses launching into that compartment. This suite
+// verifies end-to-end that a quota failure launching into one compartment still lets a NodePool
+// whose NodeClass targets a different compartment schedule the same shape (rather than being
+// globally suppressed the way a tenancy-scoped LimitExceeded or host-capacity failure would be).
+var _ = Describe("CloudProvider Compartment Scoping", func() {
+	const (
+		zone         = "PHX-AD-1"
+		compartmentA = "ocid1.compartment.oc1..aaaa"
+		compartmentB = "ocid1.compartment.oc1..bbbb"
+	)
+
+	var (
+		shape             string
+		classA            *v1beta1.OCINodeClass
+		classB            *v1beta1.OCINodeClass
+		unavailable       *ocicache.UnavailableOfferings
+		instanceProvider  *FakeInstanceProvider
+		cp                *CloudProvider
+		cluster           *state.Cluster
+		prov              *provisioning.Provisioner
+		provCtx           context.Context
+		poolA             *v1.NodePool
+		poolB             *v1.NodePool
+		smallPodResources corev1.ResourceRequirements
+	)
+
+	BeforeEach(func() {
+		shape = uniqueName("shape")
+		unavailable = ocicache.NewUnavailableOfferings(ocicache.UnavailableOfferingsTTL)
+
+		// Both NodeClasses resolve to the SAME shape and differ only by target compartment.
+		classA = testReadyNodeClass(uniqueName("class-a"))
+		classA.Spec.NodeCompartmentId = lo.ToPtr(compartmentA)
+		classB = testReadyNodeClass(uniqueName("class-b"))
+		classB.Spec.NodeCompartmentId = lo.ToPtr(compartmentB)
+
+		// Offering availability is gated on the shared unavailable-offerings cache using the same
+		// two-scope lookup as production setOfferings: the tenancy-wide entry plus an entry scoped to
+		// the NodeClass's target compartment.
+		instanceTypeProvider := &FakeInstanceTypeProvider{
+			ListFn: func(_ context.Context, nodeClass *v1beta1.OCINodeClass,
+				_ []corev1.Taint) ([]*instancetype.OciInstanceType, error) {
+				if nodeClass.Name != classA.Name && nodeClass.Name != classB.Name {
+					return nil, nil
+				}
+				compartment := *nodeClass.Spec.NodeCompartmentId
+				it := fallbackTestInstanceType(shape, 10)
+				for _, o := range it.Offerings {
+					if unavailable.IsUnavailable(shape, it.Ocpu, it.MemoryInGbs, o.Zone(), o.CapacityType(), "") ||
+						unavailable.IsUnavailable(shape, it.Ocpu, it.MemoryInGbs, o.Zone(), o.CapacityType(),
+							compartment) {
+						o.Available = false
+					}
+				}
+				return []*instancetype.OciInstanceType{it}, nil
+			},
+		}
+
+		instanceProvider = &FakeInstanceProvider{
+			LaunchInstanceFn: func(_ context.Context, nc *v1.NodeClaim, _ *v1beta1.OCINodeClass,
+				it *instancetype.OciInstanceType, _ *image.ImageResolveResult, _ *network.NetworkResolveResult,
+				_ *kms.KmsKeyResolveResult, _ *placement.Proposal) (*instance.InstanceInfo, error) {
+				return &instance.InstanceInfo{
+					Instance: testInstanceWithShape(it.Shape, nc.Labels[v1.NodePoolLabelKey]),
+				}, nil
+			},
+		}
+
+		cp = newUnitTestCloudProvider(unitTestCloudProviderOptions{
+			kubeClient:           k8sClient,
+			instanceTypeProvider: instanceTypeProvider,
+			instanceProvider:     instanceProvider,
+		})
+
+		clk := clock.RealClock{}
+		recorder := events.NewRecorder(&record.FakeRecorder{})
+		cluster = state.NewCluster(clk, k8sClient, cp)
+		prov = provisioning.NewProvisioner(k8sClient, recorder, cp, cluster, clk)
+		provCtx = coreoptions.ToContext(ctx, coretest.Options())
+
+		// Pool A has the higher weight so the scheduler tries it (compartment A) first.
+		poolA = fallbackTestNodePool(uniqueName("pool-a"), classA.Name, 100)
+		poolB = fallbackTestNodePool(uniqueName("pool-b"), classB.Name, 10)
+
+		ExpectApplied(provCtx, k8sClient, classA, classB, poolA, poolB)
+
+		smallPodResources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1500m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ExpectDeleted(provCtx, k8sClient, poolA, poolB, classA, classB)
+	})
+
+	It("keeps a different compartment schedulable when a QuotaExceeded failure is compartment-scoped", func() {
+		// The launch into compartment A fails with QuotaExceeded. Emulate the production
+		// LaunchInstance defer by marking the offering unavailable scoped to compartment A; the
+		// FakeInstanceProvider does not run the real defer. CloudProvider.Create classifies this as an
+		// InsufficientCapacityError, so no node is created this round.
+		instanceProvider.LaunchInstanceFn = func(_ context.Context, nc *v1.NodeClaim,
+			nodeClass *v1beta1.OCINodeClass, it *instancetype.OciInstanceType, _ *image.ImageResolveResult,
+			_ *network.NetworkResolveResult, _ *kms.KmsKeyResolveResult,
+			_ *placement.Proposal) (*instance.InstanceInfo, error) {
+			if *nodeClass.Spec.NodeCompartmentId == compartmentA {
+				unavailable.MarkUnavailable(provCtx, shape, it.Ocpu, it.MemoryInGbs,
+					zone, v1.CapacityTypeOnDemand, compartmentA)
+				return nil, fakeServiceError{statusCode: 400, code: "QuotaExceeded",
+					message: "compartment quota exceeded"}
+			}
+			return &instance.InstanceInfo{
+				Instance: testInstanceWithShape(it.Shape, nc.Labels[v1.NodePoolLabelKey]),
+			}, nil
+		}
+
+		// Round 1: the pod schedules onto the higher-weighted pool A (compartment A), but the launch
+		// hits the compartment quota, so no binding is made.
+		pod := coretest.UnschedulablePod(coretest.PodOptions{ResourceRequirements: smallPodResources})
+		bindings := ExpectProvisioned(provCtx, k8sClient, cluster, cp, prov, pod)
+		Expect(bindings.Get(pod)).To(BeNil())
+
+		// Core's NodeClaim lifecycle deletes the NodeClaim on InsufficientCapacityError; emulate that
+		// so the failed NodeClaim is not counted as in-flight capacity on the next scheduling round.
+		for _, nc := range ExpectNodeClaims(provCtx, k8sClient) {
+			ExpectDeleted(provCtx, k8sClient, nc)
+			cluster.DeleteNodeClaim(nc.Name)
+		}
+
+		// Round 2: the offering is cached unavailable ONLY for compartment A. Pool B targets
+		// compartment B and shares the same shape, so its offering is still available and the pod
+		// schedules there rather than staying pending (which is what would happen if the quota
+		// failure were recorded tenancy-wide).
+		bindings = ExpectProvisioned(provCtx, k8sClient, cluster, cp, prov, pod)
+		binding := bindings.Get(pod)
+		Expect(binding).ToNot(BeNil())
+		Expect(binding.NodeClaim).ToNot(BeNil())
+		Expect(binding.NodeClaim.Labels[v1.NodePoolLabelKey]).To(Equal(poolB.Name))
+		Expect(binding.NodeClaim.Labels[corev1.LabelInstanceTypeStable]).To(Equal(shape))
+	})
+})
+
+// fallbackTestInstanceType builds an instance type with a single on-demand offering plus a pod
+// capacity so the core scheduler treats the resulting node as schedulable.
+func fallbackTestInstanceType(shape string, price float64) *instancetype.OciInstanceType {
+	it := testInstanceType(shape, price)
+	it.Capacity[corev1.ResourcePods] = *resource.NewQuantity(110, resource.DecimalSI)
+	return it
+}
+
+func fallbackTestNodePool(name, nodeClassName string, weight int32) *v1.NodePool {
+	return coretest.NodePool(v1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.NodePoolSpec{
+			Weight: lo.ToPtr(weight),
+			Template: v1.NodeClaimTemplate{
+				Spec: v1.NodeClaimTemplateSpec{
+					NodeClassRef: &v1.NodeClassReference{
+						Kind:  "OCINodeClass",
+						Group: v1beta1.Group,
+						Name:  nodeClassName,
+					},
+					Requirements: []v1.NodeSelectorRequirementWithMinValues{
+						{Key: corev1.LabelInstanceTypeStable, Operator: corev1.NodeSelectorOpExists},
+						{Key: v1.CapacityTypeLabelKey, Operator: corev1.NodeSelectorOpIn,
+							Values: []string{v1.CapacityTypeOnDemand}},
+					},
+				},
+			},
+		},
+	})
+}

--- a/pkg/oci/errors.go
+++ b/pkg/oci/errors.go
@@ -26,6 +26,13 @@ const (
 	OutOfHostCapacity                   = "Out of host capacity"
 )
 
+// HTTP 400 service-error codes returned when a launch is blocked by a service
+// limit or compartment quota. These are treated as skippable capacity exhaustion.
+const (
+	LimitExceeded = "LimitExceeded"
+	QuotaExceeded = "QuotaExceeded"
+)
+
 var errNotFound = errors.New("not found")
 
 // IsRetryable returns true if the given error is retriable.
@@ -63,6 +70,12 @@ func IsRetryable(err error) bool {
 		http.StatusBadGateway,         // 502
 		http.StatusServiceUnavailable, // 503
 		http.StatusGatewayTimeout:     // 504
+		// "Out of host capacity" surfaces as an HTTP 500 on LaunchInstance. Retrying it only
+		// amplifies the host-capacity shortage and contributes to 429 throttling, so treat it as
+		// non-retryable and let the capacity-fallback logic handle it instead.
+		if IsOutOfHostCapacity(err) {
+			return false
+		}
 		return true
 	}
 	return false
@@ -116,4 +129,40 @@ func IsOutOfHostCapacity(err error) bool {
 	}
 
 	return strings.Contains(err.Error(), OutOfHostCapacity)
+}
+
+// IsServiceLimitExceeded returns true when the error is an OCI service-limit or
+// compartment-quota failure (HTTP 400 LimitExceeded/QuotaExceeded). Matching is
+// code-based rather than message-based to avoid false positives.
+func IsServiceLimitExceeded(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	serviceErr, ok := common.IsServiceError(errors.Cause(err))
+	if !ok {
+		return false
+	}
+
+	switch serviceErr.GetCode() {
+	case LimitExceeded, QuotaExceeded:
+		return true
+	}
+	return false
+}
+
+// IsQuotaExceeded returns true when the error is an OCI compartment-quota failure
+// (HTTP 400 QuotaExceeded). Quotas are administrator-defined and scoped to a specific
+// compartment and resource, unlike tenancy-scoped service limits (LimitExceeded).
+func IsQuotaExceeded(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	serviceErr, ok := common.IsServiceError(errors.Cause(err))
+	if !ok {
+		return false
+	}
+
+	return serviceErr.GetCode() == QuotaExceeded
 }

--- a/pkg/oci/errors_test.go
+++ b/pkg/oci/errors_test.go
@@ -109,6 +109,15 @@ func TestIsRetryable(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "non-retryable 500 out of host capacity",
+			err: fakeServiceError{
+				httpStatus: http.StatusInternalServerError,
+				code:       "InternalError",
+				message:    "Out of host capacity.",
+			},
+			want: false,
+		},
+		{
 			name: "retryable 502",
 			err: fakeServiceError{
 				httpStatus: http.StatusBadGateway,
@@ -141,6 +150,15 @@ func TestIsRetryable(t *testing.T) {
 				httpStatus: http.StatusNotFound,
 				code:       "NotFound",
 				message:    "not found",
+			},
+			want: false,
+		},
+		{
+			name: "non-retryable 400 limit exceeded",
+			err: fakeServiceError{
+				httpStatus: http.StatusBadRequest,
+				code:       LimitExceeded,
+				message:    "service limit exceeded",
 			},
 			want: false,
 		},
@@ -234,4 +252,34 @@ func TestIsOutOfHostCapacity(t *testing.T) {
 	}))
 
 	assert.False(t, IsOutOfHostCapacity(stderrs.New("generic")))
+}
+
+func TestIsServiceLimitExceeded(t *testing.T) {
+	assert.False(t, IsServiceLimitExceeded(nil))
+
+	assert.True(t, IsServiceLimitExceeded(fakeServiceError{
+		httpStatus: http.StatusBadRequest,
+		code:       LimitExceeded,
+		message:    "service limit exceeded",
+	}))
+
+	assert.True(t, IsServiceLimitExceeded(fakeServiceError{
+		httpStatus: http.StatusBadRequest,
+		code:       QuotaExceeded,
+		message:    "compartment quota exceeded",
+	}))
+
+	assert.True(t, IsServiceLimitExceeded(pkgerrors.Wrap(fakeServiceError{
+		httpStatus: http.StatusBadRequest,
+		code:       LimitExceeded,
+		message:    "service limit exceeded",
+	}, "wrapped")))
+
+	assert.False(t, IsServiceLimitExceeded(fakeServiceError{
+		httpStatus: http.StatusBadRequest,
+		code:       "SomeOtherCode",
+		message:    "bad request",
+	}))
+
+	assert.False(t, IsServiceLimitExceeded(stderrs.New("generic")))
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -14,6 +14,7 @@ import (
 	"os/user"
 	"time"
 
+	"github.com/oracle/karpenter-provider-oci/pkg/cache"
 	"github.com/oracle/karpenter-provider-oci/pkg/oci"
 	"github.com/oracle/karpenter-provider-oci/pkg/operator/options"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/blockstorage"
@@ -127,11 +128,17 @@ func createOperator(ctx context.Context, coreOp *operator.Operator,
 
 	identityProvider := lo.Must(identity.NewProvider(ctx, ociOptions.ClusterCompartmentId, ociClient))
 
+	// shared cache of offerings recently observed to be out of host capacity, used to drive
+	// spot->on-demand and cross-NodePool fallback.
+	unavailableOfferings := cache.NewUnavailableOfferings(
+		time.Duration(ociOptions.UnavailableOfferingsTTLSeconds) * time.Second)
+
 	instanceTypeProvider := lo.Must(instancetype.New(ctx, region, ociOptions.ClusterCompartmentId,
 		ociClient, identityProvider, clientSet, coreOp.GetAPIReader(),
 		capacityReservationProvider, computeClusterProvider, clusterPlacementGroupProvider,
 		shapeMetaFile, refreshInterval, ociOptions.GlobalShapeConfigs,
 		ociOptions.IpFamiliesFlag.IpFamilies,
+		unavailableOfferings,
 		coreOp.Elected()))
 
 	networkProvider := lo.Must(network.NewProvider(ctx, ociOptions.VcnCompartmentId,
@@ -148,7 +155,8 @@ func createOperator(ctx context.Context, coreOp *operator.Operator,
 	instancePollInterval := time.Duration(ociOptions.InstanceOperationPollIntervalInSeconds) * time.Second
 	instanceProvider := lo.Must(instance.NewProvider(ctx, ociClient, ociClient,
 		ociOptions.ClusterCompartmentId, instanceMetadataProvider, networkProvider,
-		vmTimeout, bmTimeout, ociOptions.InstanceLaunchTimeOutFailOver, instancePollInterval))
+		vmTimeout, bmTimeout, ociOptions.InstanceLaunchTimeOutFailOver, instancePollInterval,
+		unavailableOfferings))
 
 	imageProvider := lo.Must(image.NewProvider(ctx, clientSet, ociClient,
 		ociOptions.PreBakedImageCompartmentId, "", coreOp.Elected()))

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	ociv1beta1 "github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
+	"github.com/oracle/karpenter-provider-oci/pkg/cache"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/network"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -41,6 +42,7 @@ type Options struct {
 	InstanceLaunchTimeoutBMMins            int
 	InstanceOperationPollIntervalInSeconds int
 	InstanceLaunchTimeOutFailOver          bool
+	UnavailableOfferingsTTLSeconds         int
 	DisableRateLimiter                     bool
 	RateLimitQPSRead                       float64
 	RateLimitBurstRead                     int
@@ -117,6 +119,10 @@ Example in a JSON format:
 		"Intervals in seconds to decide how often instance operation result is checked")
 	fs.BoolVar(&o.InstanceLaunchTimeOutFailOver, "instance-launch-timeout-failover", false,
 		"When instance launch timeout happens, fail over to next instance types")
+	fs.IntVar(&o.UnavailableOfferingsTTLSeconds, "unavailable-offerings-ttl-seconds",
+		int(cache.UnavailableOfferingsTTL.Seconds()),
+		"How long, in seconds, an offering observed to be out of host capacity is treated as "+
+			"unavailable before Karpenter retries it. Set to 0 to disable the unavailable-offerings cache")
 	fs.BoolVar(&o.DisableRateLimiter, "disable-rate-limiter", true,
 		"Disable the OCI client-side rate limiter")
 	fs.Float64Var(&o.RateLimitQPSRead, "rate-limit-qps-read", 0,
@@ -215,6 +221,9 @@ func (o *Options) Validate() error {
 
 	if o.InstanceLaunchTimeoutBMMins <= 0 {
 		return errors.New("delete-instance-timeout-bm-mins must be a positive integer")
+	}
+	if o.UnavailableOfferingsTTLSeconds < 0 {
+		return errors.New("unavailable-offerings-ttl-seconds must be zero (to disable) or a positive integer")
 	}
 	if o.RateLimitQPSRead < 0 {
 		return errors.New("rate-limit-qps-read must be greater than or equal to 0")

--- a/pkg/operator/options/options_test.go
+++ b/pkg/operator/options/options_test.go
@@ -89,6 +89,33 @@ var _ = Describe("Test Operator Options", func() {
 			},
 			{
 				&Options{
+					ClusterCompartmentId:           "testClusterCompartmentId",
+					VcnCompartmentId:               "testVcnCompartmentId",
+					PreBakedImageCompartmentId:     "testPreBakedImageCompartmentId",
+					ApiserverEndpoint:              "1.0.10.1",
+					ShapeMetaRefreshIntervalHours:  1,
+					InstanceLaunchTimeoutVMMins:    1,
+					InstanceLaunchTimeoutBMMins:    1,
+					UnavailableOfferingsTTLSeconds: -1,
+				},
+				"unavailable-offerings-ttl-seconds must be zero (to disable) or a positive integer",
+			},
+			{
+				// A ttl of 0 is valid and disables the unavailable-offerings cache.
+				&Options{
+					ClusterCompartmentId:           "testClusterCompartmentId",
+					VcnCompartmentId:               "testVcnCompartmentId",
+					PreBakedImageCompartmentId:     "testPreBakedImageCompartmentId",
+					ApiserverEndpoint:              "1.0.10.1",
+					ShapeMetaRefreshIntervalHours:  1,
+					InstanceLaunchTimeoutVMMins:    1,
+					InstanceLaunchTimeoutBMMins:    1,
+					UnavailableOfferingsTTLSeconds: 0,
+				},
+				"",
+			},
+			{
+				&Options{
 					GlobalShapeConfigs: []ociv1beta1.ShapeConfig{{}},
 				},
 				"global-shape-configs[0] ocpus must be >= 1",
@@ -108,26 +135,28 @@ var _ = Describe("Test Operator Options", func() {
 						{Ocpus: lo.ToPtr(float32(8))},
 						{Ocpus: lo.ToPtr(float32(2))},
 					},
-					ClusterCompartmentId:          "testClusterCompartmentId",
-					VcnCompartmentId:              "testVcnCompartmentId",
-					PreBakedImageCompartmentId:    "testPreBakedImageCompartmentId",
-					ApiserverEndpoint:             "1.0.10.1",
-					ShapeMetaRefreshIntervalHours: 1,
-					InstanceLaunchTimeoutVMMins:   1,
-					InstanceLaunchTimeoutBMMins:   1,
+					ClusterCompartmentId:           "testClusterCompartmentId",
+					VcnCompartmentId:               "testVcnCompartmentId",
+					PreBakedImageCompartmentId:     "testPreBakedImageCompartmentId",
+					ApiserverEndpoint:              "1.0.10.1",
+					ShapeMetaRefreshIntervalHours:  1,
+					InstanceLaunchTimeoutVMMins:    1,
+					InstanceLaunchTimeoutBMMins:    1,
+					UnavailableOfferingsTTLSeconds: 1,
 				},
 				"",
 			},
 			{
 				&Options{
-					ClusterCompartmentId:          "testClusterCompartmentId",
-					VcnCompartmentId:              "testVcnCompartmentId",
-					PreBakedImageCompartmentId:    "testPreBakedImageCompartmentId",
-					ApiserverEndpoint:             "1.0.10.1",
-					ShapeMetaRefreshIntervalHours: 1,
-					InstanceLaunchTimeoutVMMins:   1,
-					InstanceLaunchTimeoutBMMins:   1,
-					RateLimitQPSRead:              -1,
+					ClusterCompartmentId:           "testClusterCompartmentId",
+					VcnCompartmentId:               "testVcnCompartmentId",
+					PreBakedImageCompartmentId:     "testPreBakedImageCompartmentId",
+					ApiserverEndpoint:              "1.0.10.1",
+					ShapeMetaRefreshIntervalHours:  1,
+					InstanceLaunchTimeoutVMMins:    1,
+					InstanceLaunchTimeoutBMMins:    1,
+					UnavailableOfferingsTTLSeconds: 1,
+					RateLimitQPSRead:               -1,
 				},
 				"rate-limit-qps-read must be greater than or equal to 0",
 			},
@@ -168,6 +197,7 @@ var _ = Describe("Test Operator Options", func() {
 			"instance-launch-timeout-bm-mins",
 			"instance-operation-poll-interval-seconds",
 			"instance-launch-timeout-failover",
+			"unavailable-offerings-ttl-seconds",
 			"disable-rate-limiter",
 			"rate-limit-qps-read",
 			"rate-limit-burst-read",
@@ -217,6 +247,8 @@ var _ = Describe("Test Operator Options", func() {
 			"--instance-operation-poll-interval-seconds",
 			"5",
 			"--instance-launch-timeout-failover", // "true"
+			"--unavailable-offerings-ttl-seconds",
+			"90",
 			"--disable-rate-limiter",
 			"--rate-limit-qps-read",
 			"21",
@@ -260,6 +292,7 @@ var _ = Describe("Test Operator Options", func() {
 		Expect(o.InstanceLaunchTimeoutBMMins).To(Equal(30))
 		Expect(o.InstanceOperationPollIntervalInSeconds).To(Equal(5))
 		Expect(o.InstanceLaunchTimeOutFailOver).To(BeTrue())
+		Expect(o.UnavailableOfferingsTTLSeconds).To(Equal(90))
 		Expect(o.DisableRateLimiter).To(BeTrue())
 		Expect(o.RateLimitQPSRead).To(Equal(float64(21)))
 		Expect(o.RateLimitBurstRead).To(Equal(6))

--- a/pkg/providers/instance/error.go
+++ b/pkg/providers/instance/error.go
@@ -27,3 +27,13 @@ func IsNoCapacityError(err error) bool {
 
 	return oci.IsOutOfHostCapacity(err)
 }
+
+// IsSkippableLaunchError returns true for launch failures that should be skipped
+// in favor of trying another shape/offering: host-capacity exhaustion and
+// service-limit/compartment-quota exhaustion. When every candidate shape fails
+// with a skippable error, the caller surfaces an InsufficientCapacityError so
+// core Karpenter deletes and reschedules the NodeClaim onto another offering or
+// NodePool.
+func IsSkippableLaunchError(err error) bool {
+	return IsNoCapacityError(err) || oci.IsServiceLimitExceeded(err)
+}

--- a/pkg/providers/instance/error_test.go
+++ b/pkg/providers/instance/error_test.go
@@ -1,0 +1,120 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package instance
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oracle/karpenter-provider-oci/pkg/oci"
+)
+
+// fakeServiceError implements the OCI SDK common.ServiceError interface so tests
+// can exercise the error classifiers without a live API.
+type fakeServiceError struct {
+	httpStatus int
+	code       string
+	message    string
+}
+
+func (e fakeServiceError) Error() string           { return e.message }
+func (e fakeServiceError) GetHTTPStatusCode() int  { return e.httpStatus }
+func (e fakeServiceError) GetMessage() string      { return e.message }
+func (e fakeServiceError) GetCode() string         { return e.code }
+func (e fakeServiceError) GetOpcRequestID() string { return "" }
+
+func limitExceededError() error {
+	return fakeServiceError{
+		httpStatus: http.StatusBadRequest,
+		code:       oci.LimitExceeded,
+		message:    "service limit exceeded",
+	}
+}
+
+func outOfHostCapacityError() error {
+	return fakeServiceError{
+		httpStatus: http.StatusInternalServerError,
+		code:       "InternalError",
+		message:    "Out of host capacity.",
+	}
+}
+
+func quotaExceededError() error {
+	return fakeServiceError{
+		httpStatus: http.StatusBadRequest,
+		code:       oci.QuotaExceeded,
+		message:    "compartment quota exceeded",
+	}
+}
+
+func TestIsSkippableLaunchError(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "no capacity error",
+			err:  NoCapacityError{},
+			want: true,
+		},
+		{
+			name: "out of host capacity",
+			err:  outOfHostCapacityError(),
+			want: true,
+		},
+		{
+			name: "service limit exceeded",
+			err:  limitExceededError(),
+			want: true,
+		},
+		{
+			name: "quota exceeded",
+			err: fakeServiceError{
+				httpStatus: http.StatusBadRequest,
+				code:       oci.QuotaExceeded,
+				message:    "compartment quota exceeded",
+			},
+			want: true,
+		},
+		{
+			name: "wrapped service limit exceeded",
+			err:  pkgerrors.Wrap(limitExceededError(), "wrapped"),
+			want: true,
+		},
+		{
+			name: "unrelated service error",
+			err: fakeServiceError{
+				httpStatus: http.StatusBadRequest,
+				code:       "SomeOtherCode",
+				message:    "bad request",
+			},
+			want: false,
+		},
+		{
+			name: "generic error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsSkippableLaunchError(tc.err))
+		})
+	}
+}

--- a/pkg/providers/instance/provider.go
+++ b/pkg/providers/instance/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/network"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/npn"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/placement"
+	"github.com/oracle/karpenter-provider-oci/pkg/utils"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	ocicore "github.com/oracle/oci-go-sdk/v65/core"
 	ociwr "github.com/oracle/oci-go-sdk/v65/workrequests"
@@ -89,6 +90,7 @@ type DefaultProvider struct {
 	launchTimeoutBM       time.Duration
 	launchTimeOutFailOver bool
 	pollInterval          time.Duration
+	unavailableOfferings  *cache.UnavailableOfferings
 }
 
 func NewProvider(ctx context.Context, computeClient oci.ComputeClient,
@@ -98,7 +100,8 @@ func NewProvider(ctx context.Context, computeClient oci.ComputeClient,
 	networkProvider network.Provider,
 	launchTimeoutVM, launchTimeoutBM time.Duration,
 	launchTimeOutFailOver bool,
-	pollInterval time.Duration) (*DefaultProvider, error) {
+	pollInterval time.Duration,
+	unavailableOfferings *cache.UnavailableOfferings) (*DefaultProvider, error) {
 	p := &DefaultProvider{
 		computeClient:         computeClient,
 		workRequestClient:     workRequestClient,
@@ -112,6 +115,7 @@ func NewProvider(ctx context.Context, computeClient oci.ComputeClient,
 		launchTimeoutBM:       launchTimeoutBM,
 		launchTimeOutFailOver: launchTimeOutFailOver,
 		pollInterval:          pollInterval,
+		unavailableOfferings:  unavailableOfferings,
 	}
 
 	return p, nil
@@ -124,7 +128,7 @@ func (p *DefaultProvider) LaunchInstance(ctx context.Context,
 	imageResolveResult *image.ImageResolveResult,
 	networkResolveResult *network.NetworkResolveResult,
 	kmsKeyResolveResult *kms.KmsKeyResolveResult,
-	placementProposal *placement.Proposal) (*InstanceInfo, error) {
+	placementProposal *placement.Proposal) (result *InstanceInfo, err error) {
 	imageSource := ocicore.InstanceSourceViaImageDetails{
 		ImageId:  imageResolveResult.Images[0].Id,
 		KmsKeyId: nil,
@@ -142,13 +146,59 @@ func (p *DefaultProvider) LaunchInstance(ctx context.Context,
 		imageSource.BootVolumeVpusPerGB = nodeClass.Spec.VolumeConfig.BootVolumeConfig.VpusPerGB
 	}
 
+	capacityType := decideCapacityType(ctx, nodeClaim, instanceType)
 	var preemptibleInstanceConfig *ocicore.PreemptibleInstanceConfigDetails
 	isPreemptible := false
-	if decideCapacityType(ctx, nodeClaim, instanceType) == corev1.CapacityTypeSpot {
+	if capacityType == corev1.CapacityTypeSpot {
 		preemptibleInstanceConfig = &ocicore.PreemptibleInstanceConfigDetails{
 			PreemptionAction: &ocicore.TerminatePreemptionAction{},
 		}
 		isPreemptible = true
+	}
+
+	// When a launch attempt fails because of a skippable capacity exhaustion (host-capacity
+	// shortage or service-limit/compartment-quota), record the
+	// (shape, ocpu/memory, AD/zone, capacity-type) offering as unavailable so it is excluded from
+	// offering availability until the cache entry expires, enabling spot->on-demand and
+	// cross-NodePool fallback. Scoping by the flexible-shape CPU/memory configuration keeps a
+	// failure for one config from suppressing the shape's other configs.
+	if p.unavailableOfferings != nil {
+		defer func() {
+			if !IsSkippableLaunchError(err) {
+				return
+			}
+
+			// The unavailable-offerings cache key does not include placement scope
+			// (capacity reservation, compute cluster, cluster placement group, or fault domain).
+			// A failure scoped to one of those is narrower than the generic
+			// (shape, config, zone, capacity-type) key, so caching it would wrongly suppress
+			// otherwise-valid generic capacity for other NodeClaims. Two proposals can only share
+			// this key if they differ by one of these fields, so skipping them here also prevents a
+			// single failed proposal from suppressing an offering another proposal could still
+			// launch. This deliberately gives up cache-based fallback for placement-scoped
+			// failures; a future solution could include the placement scope in the cache key.
+			if placementProposal.CapacityReservationId != nil ||
+				placementProposal.ComputeClusterId != nil ||
+				placementProposal.ClusterPlacementGroupId != nil ||
+				placementProposal.Fd != nil {
+				return
+			}
+
+			// QuotaExceeded is an administrator-defined quota failure for a specific compartment
+			// and resource, so scope the cache entry to the target compartment; otherwise a quota
+			// failure in one node compartment would wrongly suppress the same offering for
+			// NodeClasses launching into other compartments. Host-capacity exhaustion and
+			// tenancy-scoped LimitExceeded service limits apply regardless of compartment, so they
+			// use an empty (tenancy-wide) compartment scope.
+			compartment := ""
+			if oci.IsQuotaExceeded(err) {
+				compartment = p.GetInstanceCompartment(nodeClass)
+			}
+
+			p.unavailableOfferings.MarkUnavailable(ctx, instanceType.Shape,
+				instanceType.Ocpu, instanceType.MemoryInGbs,
+				utils.AdToZoneLabelValue(placementProposal.Ad), capacityType, compartment)
+		}()
 	}
 
 	metadata, err := p.instanceMetaProvider.BuildInstanceMetadata(ctx, nodeClaim, nodeClass,

--- a/pkg/providers/instance/provider_test.go
+++ b/pkg/providers/instance/provider_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/network"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/npn"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/placement"
+	"github.com/oracle/karpenter-provider-oci/pkg/utils"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -121,6 +122,8 @@ func minimalPlacement() *placement.Proposal {
 	pr := &placement.Proposal{Ad: "tenancy:PHX-AD-1", Fd: lo.ToPtr("FAULT-DOMAIN-1")}
 	return pr
 }
+
+const testShapeE4Flex = "VM.Standard.E4.Flex"
 
 func TestProvider_BuildDefinedTags(t *testing.T) {
 	tests := []struct {
@@ -339,6 +342,25 @@ func TestProvider_DecideCapacityType(t *testing.T) {
 			},
 			offerings: cloudprovider.Offerings{makeOffering(corev1.CapacityTypeOnDemand)},
 			want:      corev1.CapacityTypeOnDemand,
+		},
+		{
+			name:        "on-demand when spot offering is unavailable",
+			isBurstable: false,
+			claimReqs: []corev1.NodeSelectorRequirementWithMinValues{
+				{Key: corev1.CapacityTypeLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{corev1.CapacityTypeSpot}},
+			},
+			offerings: cloudprovider.Offerings{
+				{
+					Available: false,
+					Requirements: scheduling.NewRequirements(
+						scheduling.NewRequirement(corev1.CapacityTypeLabelKey, v1.NodeSelectorOpIn,
+							corev1.CapacityTypeSpot),
+					),
+					Price: 0.1,
+				},
+				makeOffering(corev1.CapacityTypeOnDemand),
+			},
+			want: corev1.CapacityTypeOnDemand,
 		},
 	}
 	for _, tt := range tests {
@@ -824,6 +846,33 @@ func TestProvider_LaunchInstance_RequestConstruction(t *testing.T) {
 		require.NotNil(t, fc.LastLaunchReq.LaunchInstanceDetails.PreemptibleInstanceConfig, "expected preemptible config")
 	})
 
+	t.Run("on-demand fallback when spot offering is unavailable", func(t *testing.T) {
+		claim := baseClaim.DeepCopy()
+		// NodePool allows both spot and on-demand, with spot preferred.
+		claim.Spec.Requirements = []corev1.NodeSelectorRequirementWithMinValues{
+			{Key: corev1.CapacityTypeLabelKey, Operator: v1.NodeSelectorOpIn,
+				Values: []string{corev1.CapacityTypeSpot, corev1.CapacityTypeOnDemand}},
+		}
+		// The shape's only spot offering is out of host capacity (Available=false, as the
+		// unavailable-offerings cache surfaces it via setOfferings), leaving on-demand available.
+		it := &instancetype.OciInstanceType{Shape: "VM.Standard.E4.Flex"}
+		spotUnavailable := makeOfferingWithCapType(corev1.CapacityTypeSpot)
+		spotUnavailable.Available = false
+		it.Offerings = cloudprovider.Offerings{
+			spotUnavailable,
+			makeOfferingWithCapType(corev1.CapacityTypeOnDemand),
+		}
+		nodeClass := baseNodeClass.DeepCopy()
+
+		_, err := p.LaunchInstance(context.TODO(), claim, nodeClass,
+			it, imgRes, netRes, nil, pp)
+		require.NoError(t, err)
+		// decideCapacityType should fall back to on-demand within the same pool, so the launch
+		// request must not carry a preemptible (spot) config.
+		require.Nil(t, fc.LastLaunchReq.LaunchInstanceDetails.PreemptibleInstanceConfig,
+			"expected on-demand fallback (no preemptible config) when the spot offering is unavailable")
+	})
+
 	t.Run("non-flexible should not set shape config", func(t *testing.T) {
 		claim := baseClaim.DeepCopy()
 		claim.Spec.Requirements = []corev1.NodeSelectorRequirementWithMinValues{
@@ -1142,6 +1191,205 @@ func TestProvider_LaunchInstance_FailurePaths(t *testing.T) {
 		fc.LaunchErr = nil
 	})
 
+}
+
+func TestProvider_LaunchInstance_MarksUnavailableOnSkippableError(t *testing.T) {
+	baseNodeClass := minimalNodeClass()
+	baseClaim := minimalNodeClaim()
+	imgRes := minimalImageResolve()
+	netRes := minimalNetworkResolve()
+	// An unscoped (generic) proposal: no capacity reservation, compute cluster, cluster placement
+	// group, or fault domain, so the offering is eligible to be cached as unavailable.
+	pp := minimalPlacement()
+	pp.Fd = nil
+
+	shape := testShapeE4Flex
+	zone := utils.AdToZoneLabelValue(pp.Ad)
+	ocpu := lo.ToPtr(float32(2))
+	memory := lo.ToPtr(float32(16))
+
+	testCases := []struct {
+		name string
+		err  error
+	}{
+		{name: "out of host capacity", err: outOfHostCapacityError()},
+		{name: "service limit exceeded", err: limitExceededError()},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakes.FakeCompute{LaunchErr: tc.err}
+			unavailable := cache.NewUnavailableOfferings(cache.UnavailableOfferingsTTL)
+			p := &DefaultProvider{
+				computeClient:        fc,
+				clusterCompartmentId: "ocid1.compartment.oc1..parent",
+				instanceCache:        cache.NewDefaultGetOrLoadCache[*InstanceInfo](),
+				vnicAttachCache:      cache.NewDefaultGetOrLoadCache[[]*ocicore.VnicAttachment](),
+				bootVolAttachCache:   cache.NewDefaultGetOrLoadCache[[]*ocicore.BootVolumeAttachment](),
+				launchTimeoutVM:      10 * time.Minute,
+				launchTimeoutBM:      20 * time.Minute,
+				pollInterval:         time.Second,
+				unavailableOfferings: unavailable,
+			}
+			imdsp, err := instancemeta.NewProvider(context.TODO(), "10.0.0.1", []byte("CA"), ipV4SingleStack)
+			require.NoError(t, err)
+			p.instanceMetaProvider = imdsp
+
+			// baseClaim has no capacity-type requirement, so decideCapacityType returns on-demand.
+			_, err = p.LaunchInstance(context.TODO(), baseClaim, baseNodeClass,
+				&instancetype.OciInstanceType{Shape: shape, SupportShapeConfig: true, Ocpu: ocpu, MemoryInGbs: memory},
+				imgRes, netRes, nil, pp)
+			require.Error(t, err)
+			// Host-capacity exhaustion and tenancy-scoped LimitExceeded apply regardless of
+			// compartment, so they are recorded under the tenancy-wide (empty compartment) scope.
+			assert.True(t, unavailable.IsUnavailable(shape, ocpu, memory, zone, corev1.CapacityTypeOnDemand, ""),
+				"expected the (shape, ocpu/memory, zone, capacity-type) offering to be marked unavailable")
+
+			// A different CPU/memory configuration of the same shape/zone/capacity-type must remain
+			// available, since only the failed config was observed to be out of capacity.
+			assert.False(t,
+				unavailable.IsUnavailable(shape, lo.ToPtr(float32(4)), memory, zone, corev1.CapacityTypeOnDemand, ""),
+				"a different flex config must not be suppressed by the failed config")
+		})
+	}
+}
+
+func TestProvider_LaunchInstance_MarksQuotaExceededScopedToCompartment(t *testing.T) {
+	baseClaim := minimalNodeClaim()
+	imgRes := minimalImageResolve()
+	netRes := minimalNetworkResolve()
+	// An unscoped (generic) proposal so the QuotaExceeded failure is eligible for caching.
+	pp := minimalPlacement()
+	pp.Fd = nil
+
+	shape := testShapeE4Flex
+	zone := utils.AdToZoneLabelValue(pp.Ad)
+	ocpu := lo.ToPtr(float32(2))
+	memory := lo.ToPtr(float32(16))
+
+	const (
+		clusterCompartment = "ocid1.compartment.oc1..parent"
+		nodeCompartment    = "ocid1.compartment.oc1..node"
+		otherCompartment   = "ocid1.compartment.oc1..other"
+	)
+
+	// The NodeClass launches into an explicit node compartment distinct from the cluster
+	// compartment, so a QuotaExceeded failure must be scoped to that node compartment.
+	nodeClass := minimalNodeClass()
+	nodeClass.Spec.NodeCompartmentId = lo.ToPtr(nodeCompartment)
+
+	fc := &fakes.FakeCompute{LaunchErr: quotaExceededError()}
+	unavailable := cache.NewUnavailableOfferings(cache.UnavailableOfferingsTTL)
+	p := &DefaultProvider{
+		computeClient:        fc,
+		clusterCompartmentId: clusterCompartment,
+		instanceCache:        cache.NewDefaultGetOrLoadCache[*InstanceInfo](),
+		vnicAttachCache:      cache.NewDefaultGetOrLoadCache[[]*ocicore.VnicAttachment](),
+		bootVolAttachCache:   cache.NewDefaultGetOrLoadCache[[]*ocicore.BootVolumeAttachment](),
+		launchTimeoutVM:      10 * time.Minute,
+		launchTimeoutBM:      20 * time.Minute,
+		pollInterval:         time.Second,
+		unavailableOfferings: unavailable,
+	}
+	imdsp, err := instancemeta.NewProvider(context.TODO(), "10.0.0.1", []byte("CA"), ipV4SingleStack)
+	require.NoError(t, err)
+	p.instanceMetaProvider = imdsp
+
+	_, err = p.LaunchInstance(context.TODO(), baseClaim, nodeClass,
+		&instancetype.OciInstanceType{Shape: shape, SupportShapeConfig: true, Ocpu: ocpu, MemoryInGbs: memory},
+		imgRes, netRes, nil, pp)
+	require.Error(t, err)
+
+	// The offering is unavailable only for the target node compartment.
+	assert.True(t, unavailable.IsUnavailable(shape, ocpu, memory, zone, corev1.CapacityTypeOnDemand, nodeCompartment),
+		"expected the offering to be marked unavailable for the target node compartment")
+	// Other compartments and the tenancy-wide scope stay available.
+	assert.False(t, unavailable.IsUnavailable(shape, ocpu, memory, zone, corev1.CapacityTypeOnDemand, otherCompartment),
+		"a QuotaExceeded failure must not suppress the offering for another compartment")
+	assert.False(t, unavailable.IsUnavailable(shape, ocpu, memory, zone, corev1.CapacityTypeOnDemand, ""),
+		"a QuotaExceeded failure must not suppress the offering tenancy-wide")
+}
+
+// A skippable (out-of-capacity) launch failure for a placement-scoped proposal must not pollute the
+// generic (shape, ocpu/memory, zone, capacity-type) offering. The unavailable-offerings cache key
+// omits placement scope (capacity reservation, compute cluster, cluster placement group, fault
+// domain), so recording a placement-scoped failure under that key would wrongly hide otherwise-valid
+// generic capacity from other NodeClaims.
+func TestProvider_LaunchInstance_SkipsMarkUnavailableForPlacementScopedProposals(t *testing.T) {
+	baseNodeClass := minimalNodeClass()
+	baseClaim := minimalNodeClaim()
+	imgRes := minimalImageResolve()
+	netRes := minimalNetworkResolve()
+
+	shape := testShapeE4Flex
+	ocpu := lo.ToPtr(float32(2))
+	memory := lo.ToPtr(float32(16))
+
+	testCases := []struct {
+		name       string
+		decorateFn func(pp *placement.Proposal)
+	}{
+		{
+			name: "capacity reservation",
+			decorateFn: func(pp *placement.Proposal) {
+				pp.CapacityReservationId = lo.ToPtr("ocid1.capacityreservation.oc1..reservation")
+			},
+		},
+		{
+			name: "compute cluster",
+			decorateFn: func(pp *placement.Proposal) {
+				pp.ComputeClusterId = lo.ToPtr("ocid1.computecluster.oc1..cluster")
+			},
+		},
+		{
+			name: "cluster placement group",
+			decorateFn: func(pp *placement.Proposal) {
+				pp.ClusterPlacementGroupId = lo.ToPtr("ocid1.clusterplacementgroup.oc1..cpg")
+			},
+		},
+		{
+			name: "fault domain",
+			decorateFn: func(pp *placement.Proposal) {
+				pp.Fd = lo.ToPtr("FAULT-DOMAIN-1")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Start from an unscoped proposal (minimalPlacement sets a fault domain by default) so
+			// each case isolates the single placement-scope field under test.
+			pp := minimalPlacement()
+			pp.Fd = nil
+			tc.decorateFn(pp)
+			zone := utils.AdToZoneLabelValue(pp.Ad)
+
+			fc := &fakes.FakeCompute{LaunchErr: outOfHostCapacityError()}
+			unavailable := cache.NewUnavailableOfferings(cache.UnavailableOfferingsTTL)
+			p := &DefaultProvider{
+				computeClient:        fc,
+				clusterCompartmentId: "ocid1.compartment.oc1..parent",
+				instanceCache:        cache.NewDefaultGetOrLoadCache[*InstanceInfo](),
+				vnicAttachCache:      cache.NewDefaultGetOrLoadCache[[]*ocicore.VnicAttachment](),
+				bootVolAttachCache:   cache.NewDefaultGetOrLoadCache[[]*ocicore.BootVolumeAttachment](),
+				launchTimeoutVM:      10 * time.Minute,
+				launchTimeoutBM:      20 * time.Minute,
+				pollInterval:         time.Second,
+				unavailableOfferings: unavailable,
+			}
+			imdsp, err := instancemeta.NewProvider(context.TODO(), "10.0.0.1", []byte("CA"), ipV4SingleStack)
+			require.NoError(t, err)
+			p.instanceMetaProvider = imdsp
+
+			_, err = p.LaunchInstance(context.TODO(), baseClaim, baseNodeClass,
+				&instancetype.OciInstanceType{Shape: shape, SupportShapeConfig: true, Ocpu: ocpu, MemoryInGbs: memory},
+				imgRes, netRes, nil, pp)
+			require.Error(t, err)
+			assert.False(t,
+				unavailable.IsUnavailable(shape, ocpu, memory, zone, corev1.CapacityTypeOnDemand, ""),
+				"a placement-scoped launch failure must not mark the generic offering unavailable")
+		})
+	}
 }
 
 func TestProvider_Cached_Wrappers_Negative(t *testing.T) {

--- a/pkg/providers/instancetype/provider.go
+++ b/pkg/providers/instancetype/provider.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	ociv1beta1 "github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
+	"github.com/oracle/karpenter-provider-oci/pkg/cache"
 	"github.com/oracle/karpenter-provider-oci/pkg/metrics"
 	"github.com/oracle/karpenter-provider-oci/pkg/oci"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/capacityreservation"
@@ -83,6 +84,7 @@ type DefaultProvider struct {
 	kubernetesInterface           kubernetes.Interface
 	k8sVersion                    *semver.Version
 	ipFamilies                    []network.IpFamily
+	unavailableOfferings          *cache.UnavailableOfferings
 
 	lock sync.RWMutex
 }
@@ -101,6 +103,7 @@ func New(ctx context.Context,
 	metaRefreshInterval time.Duration,
 	globalShapeConfigs []ociv1beta1.ShapeConfig,
 	ipFamilies []network.IpFamily,
+	unavailableOfferings *cache.UnavailableOfferings,
 	startAsync <-chan struct{}) (*DefaultProvider, error) {
 	p := &DefaultProvider{
 		region:                        region,
@@ -116,6 +119,7 @@ func New(ctx context.Context,
 		client:                        directClient,
 		ipFamilies:                    ipFamilies,
 		kubernetesInterface:           kubernetesInterface,
+		unavailableOfferings:          unavailableOfferings,
 	}
 
 	p.GlobalShapeConfigs = lo.Map(globalShapeConfigs, func(item ociv1beta1.ShapeConfig, _ int) *ociv1beta1.ShapeConfig {
@@ -791,6 +795,17 @@ func (p *DefaultProvider) isComputeClusterSupportedShape(shapeName string) bool 
 	return lo.Contains(p.computeClusterShapes, strings.ToUpper(shapeName))
 }
 
+// instanceCompartment returns the compartment instances for the NodeClass launch into: the
+// NodeClass override if set, otherwise the cluster compartment. It mirrors the instance provider's
+// GetInstanceCompartment so unavailable-offering lookups use the same compartment scope that a
+// launch failure was recorded under.
+func (p *DefaultProvider) instanceCompartment(nodeClass *ociv1beta1.OCINodeClass) string {
+	if nodeClass.Spec.NodeCompartmentId != nil {
+		return *nodeClass.Spec.NodeCompartmentId
+	}
+	return p.clusterCompartmentId
+}
+
 func (p *DefaultProvider) setOfferings(ctx context.Context, it *OciInstanceType, nodeClass *ociv1beta1.OCINodeClass,
 	shapeAndAd *ShapeAndAd, available bool, basePrice float64, taints []v1.Taint) error {
 	placementRestrictFunc, err := p.getPlacementRestrictFunc(ctx, nodeClass)
@@ -834,9 +849,31 @@ func (p *DefaultProvider) setOfferings(ctx context.Context, it *OciInstanceType,
 
 	it.Offerings = append(it.Offerings, offerings...)
 
+	// exclude offerings recently observed to be out of host capacity. Reserved offerings keep
+	// their count-based availability untouched. Two scopes are checked: tenancy-wide entries
+	// (empty compartment) covering host-capacity exhaustion and LimitExceeded service limits, and
+	// entries scoped to this NodeClass's target compartment covering compartment-specific
+	// QuotaExceeded failures.
+	if p.unavailableOfferings != nil {
+		compartment := p.instanceCompartment(nodeClass)
+		for _, offering := range it.Offerings {
+			capType := offering.CapacityType()
+			if capType == corev1.CapacityTypeReserved {
+				continue
+			}
+			if offering.Available &&
+				(p.unavailableOfferings.IsUnavailable(*shapeAndAd.Shape.Shape,
+					it.Ocpu, it.MemoryInGbs, offering.Zone(), capType, "") ||
+					p.unavailableOfferings.IsUnavailable(*shapeAndAd.Shape.Shape,
+						it.Ocpu, it.MemoryInGbs, offering.Zone(), capType, compartment)) {
+				offering.Available = false
+			}
+		}
+	}
+
 	if len(it.Offerings) > 0 {
 		for _, offering := range it.Offerings {
-			metrics.InstanceTypeOfferingAvailable.Set(float64(lo.Ternary(available, 1, 0)), map[string]string{
+			metrics.InstanceTypeOfferingAvailable.Set(float64(lo.Ternary(offering.Available, 1, 0)), map[string]string{
 				metrics.InstanceTypeLabel: it.Name,
 				metrics.CapacityTypeLabel: offering.CapacityType(),
 				metrics.ZoneLabel:         offering.Zone(),

--- a/pkg/providers/instancetype/provider_test.go
+++ b/pkg/providers/instancetype/provider_test.go
@@ -55,6 +55,11 @@ var (
 	ipV6DualStack   = []network.IpFamily{network.IPv4, network.IPv6}
 )
 
+const (
+	testZonePHXAD1       = "PHX-AD-1"
+	testCapacityTypeSpot = "spot"
+)
+
 type fakeCapacityReservationProvider struct {
 	results []capacityreservation.ResolveResult
 	err     error
@@ -195,7 +200,7 @@ func TestMakeRequirementAndOffering(t *testing.T) {
 	// Should have capacity type and zone
 	assert.Equal(t, corev1.CapacityTypeOnDemand, reqs.Get(corev1.CapacityTypeLabelKey).Any())
 	// Zone value should be PHX-AD-1 (derived from AD)
-	assert.Equal(t, "PHX-AD-1", reqs.Get(v1.LabelTopologyZone).Any())
+	assert.Equal(t, testZonePHXAD1, reqs.Get(v1.LabelTopologyZone).Any())
 
 	off := makeOffering("tenancy:PHX-AD-1", 0.42, corev1.CapacityTypeOnDemand, true)
 	assert.True(t, off.Available)
@@ -774,7 +779,7 @@ func TestFinalizeRequirements(t *testing.T) {
 					Requirements: scheduling.NewRequirements(
 						scheduling.NewRequirement(corev1.CapacityTypeLabelKey, v1.NodeSelectorOpIn,
 							corev1.CapacityTypeOnDemand),
-						scheduling.NewRequirement(v1.LabelTopologyZone, v1.NodeSelectorOpIn, "PHX-AD-1"),
+						scheduling.NewRequirement(v1.LabelTopologyZone, v1.NodeSelectorOpIn, testZonePHXAD1),
 					),
 					Available: true,
 					Price:     0.1,
@@ -786,7 +791,7 @@ func TestFinalizeRequirements(t *testing.T) {
 	p.finalizeRequirements(it, sa)
 	// Zones captured from ShapeAndAd, OS linux, arch amd64 (E4)
 	assert.Equal(t, "amd64", it.Requirements.Get(v1.LabelArchStable).Any())
-	assert.ElementsMatch(t, []string{"PHX-AD-1", "PHX-AD-2"}, it.Requirements.Get(v1.LabelTopologyZone).Values())
+	assert.ElementsMatch(t, []string{testZonePHXAD1, "PHX-AD-2"}, it.Requirements.Get(v1.LabelTopologyZone).Values())
 	assert.Equal(t, "linux", it.Requirements.Get(v1.LabelOSStable).Any())
 }
 
@@ -1036,7 +1041,7 @@ func TestMakeReservedOffering(t *testing.T) {
 	// Should include at least one offering for AD-1 with capacity 6 (10-4)
 	found := false
 	for _, o := range offerings {
-		if o.Requirements.Get(v1.LabelTopologyZone).Any() == "PHX-AD-1" && o.ReservationCapacity == 6 {
+		if o.Requirements.Get(v1.LabelTopologyZone).Any() == testZonePHXAD1 && o.ReservationCapacity == 6 {
 			assert.Equal(t, basePrice, o.Price)
 			found = true
 			break
@@ -1188,7 +1193,7 @@ func TestFinalizeRequirements_AddsSpecialShapeRequirements(t *testing.T) {
 		Shape: "VM.Standard3.DenseIO64"}
 	p := &DefaultProvider{}
 	p.finalizeRequirements(itDense, saDense)
-	assert.True(t, itDense.Requirements.Get(v1.LabelTopologyZone).Has("PHX-AD-1"))
+	assert.True(t, itDense.Requirements.Get(v1.LabelTopologyZone).Has(testZonePHXAD1))
 	// DenseIO flag should exist
 	assert.True(t, itDense.Requirements.Get("oci.oraclecloud.com/dense-io-shape").Has("true"))
 
@@ -1235,14 +1240,164 @@ func TestSetOfferings_PreemptibleSpotAdded(t *testing.T) {
 	var hasOnDemand, hasSpot bool
 	for _, o := range it.Offerings {
 		switch o.Requirements.Get("karpenter.sh/capacity-type").Any() {
-		case "on-demand":
+		case corev1.CapacityTypeOnDemand:
 			hasOnDemand = true
-		case "spot":
+		case testCapacityTypeSpot:
 			hasSpot = true
 		}
 	}
 	assert.True(t, hasOnDemand, "expected on-demand offerings")
 	assert.True(t, hasSpot, "expected spot offerings for preemptible non-burstable shape")
+}
+
+func TestSetOfferings_ExcludesUnavailableOfferings(t *testing.T) {
+	unavailableOfferings := cache.NewUnavailableOfferings(cache.UnavailableOfferingsTTL)
+	// mark only the spot offering in PHX-AD-1 as out of host capacity.
+	unavailableOfferings.MarkUnavailable(context.Background(), "VM.Standard.E4.Flex", nil, nil,
+		testZonePHXAD1, testCapacityTypeSpot, "")
+
+	p := &DefaultProvider{
+		preemptibleShapes:    PreemptibleShapes{"VM.STANDARD.E4": "VM.Standard.E4"},
+		unavailableOfferings: unavailableOfferings,
+	}
+
+	shape := &ocicore.Shape{
+		Shape:              lo.ToPtr("VM.Standard.E4.Flex"),
+		MaxVnicAttachments: lo.ToPtr(4),
+	}
+	sa := &ShapeAndAd{Shape: shape, Ads: []string{"tenancy:PHX-AD-1", "tenancy:PHX-AD-2"}}
+	it := &OciInstanceType{
+		InstanceType: cloudprovider.InstanceType{Name: "VM.Standard.E4.Flex"},
+		Shape:        "VM.Standard.E4.Flex",
+	}
+
+	err := p.setOfferings(context.Background(), it, &ociv1beta1.OCINodeClass{}, sa, true, 1.0,
+		[]v1.Taint{preemptibleTaintNoSchedule})
+	assert.NoError(t, err)
+
+	for _, o := range it.Offerings {
+		capType := o.Requirements.Get("karpenter.sh/capacity-type").Any()
+		if capType == testCapacityTypeSpot && o.Zone() == testZonePHXAD1 {
+			assert.False(t, o.Available, "spot offering in PHX-AD-1 should be marked unavailable")
+		} else {
+			assert.True(t, o.Available, "offering %s/%s should remain available", capType, o.Zone())
+		}
+	}
+}
+
+func TestSetOfferings_ExcludesUnavailableOfferings_ScopedByFlexConfig(t *testing.T) {
+	unavailableOfferings := cache.NewUnavailableOfferings(cache.UnavailableOfferingsTTL)
+	// Mark only the 2 OCPU / 16 GB on-demand config of the flexible shape in PHX-AD-1 unavailable.
+	unavailableOfferings.MarkUnavailable(context.Background(), "VM.Standard.E4.Flex",
+		lo.ToPtr(float32(2)), lo.ToPtr(float32(16)), testZonePHXAD1, corev1.CapacityTypeOnDemand, "")
+
+	p := &DefaultProvider{
+		preemptibleShapes:    PreemptibleShapes{"VM.STANDARD.E4": "VM.Standard.E4"},
+		unavailableOfferings: unavailableOfferings,
+	}
+
+	shape := &ocicore.Shape{
+		Shape:              lo.ToPtr("VM.Standard.E4.Flex"),
+		MaxVnicAttachments: lo.ToPtr(4),
+	}
+	sa := &ShapeAndAd{Shape: shape, Ads: []string{"tenancy:PHX-AD-1", "tenancy:PHX-AD-2"}}
+
+	// The unavailable config: its PHX-AD-1 on-demand offering must be excluded.
+	unavailableIt := &OciInstanceType{
+		InstanceType:       cloudprovider.InstanceType{Name: "VM.Standard.E4.Flex.2o.16g"},
+		Shape:              "VM.Standard.E4.Flex",
+		SupportShapeConfig: true,
+		Ocpu:               lo.ToPtr(float32(2)),
+		MemoryInGbs:        lo.ToPtr(float32(16)),
+	}
+	err := p.setOfferings(context.Background(), unavailableIt, &ociv1beta1.OCINodeClass{}, sa, true, 1.0, nil)
+	assert.NoError(t, err)
+	for _, o := range unavailableIt.Offerings {
+		if o.Zone() == testZonePHXAD1 {
+			assert.False(t, o.Available, "the marked 2o/16g config in PHX-AD-1 should be unavailable")
+		} else {
+			assert.True(t, o.Available, "other zones of the marked config should remain available")
+		}
+	}
+
+	// A different CPU/memory config of the same shape/zone must remain fully available.
+	otherIt := &OciInstanceType{
+		InstanceType:       cloudprovider.InstanceType{Name: "VM.Standard.E4.Flex.4o.16g"},
+		Shape:              "VM.Standard.E4.Flex",
+		SupportShapeConfig: true,
+		Ocpu:               lo.ToPtr(float32(4)),
+		MemoryInGbs:        lo.ToPtr(float32(16)),
+	}
+	err = p.setOfferings(context.Background(), otherIt, &ociv1beta1.OCINodeClass{}, sa, true, 1.0, nil)
+	assert.NoError(t, err)
+	for _, o := range otherIt.Offerings {
+		assert.True(t, o.Available,
+			"a different flex config must not be suppressed by the marked config (%s/%s)",
+			o.Requirements.Get("karpenter.sh/capacity-type").Any(), o.Zone())
+	}
+}
+
+func TestSetOfferings_ExcludesUnavailableOfferings_ScopedByCompartment(t *testing.T) {
+	const (
+		clusterCompartment = "ocid1.compartment.oc1..cluster"
+		quotaCompartment   = "ocid1.compartment.oc1..quota"
+		otherCompartment   = "ocid1.compartment.oc1..other"
+	)
+
+	unavailableOfferings := cache.NewUnavailableOfferings(cache.UnavailableOfferingsTTL)
+	// A QuotaExceeded failure records the on-demand offering in PHX-AD-1 unavailable, scoped to a
+	// single (node) compartment.
+	unavailableOfferings.MarkUnavailable(context.Background(), "VM.Standard.E4.Flex", nil, nil,
+		testZonePHXAD1, corev1.CapacityTypeOnDemand, quotaCompartment)
+
+	p := &DefaultProvider{
+		clusterCompartmentId: clusterCompartment,
+		preemptibleShapes:    PreemptibleShapes{"VM.STANDARD.E4": "VM.Standard.E4"},
+		unavailableOfferings: unavailableOfferings,
+	}
+
+	shape := &ocicore.Shape{
+		Shape:              lo.ToPtr("VM.Standard.E4.Flex"),
+		MaxVnicAttachments: lo.ToPtr(4),
+	}
+	sa := &ShapeAndAd{Shape: shape, Ads: []string{"tenancy:PHX-AD-1", "tenancy:PHX-AD-2"}}
+
+	newIt := func() *OciInstanceType {
+		return &OciInstanceType{
+			InstanceType: cloudprovider.InstanceType{Name: "VM.Standard.E4.Flex"},
+			Shape:        "VM.Standard.E4.Flex",
+		}
+	}
+
+	// A NodeClass launching into the quota-affected compartment must have the PHX-AD-1 on-demand
+	// offering excluded.
+	inCompartmentIt := newIt()
+	nodeClassInCompartment := &ociv1beta1.OCINodeClass{}
+	nodeClassInCompartment.Spec.NodeCompartmentId = lo.ToPtr(quotaCompartment)
+	err := p.setOfferings(context.Background(), inCompartmentIt, nodeClassInCompartment, sa, true, 1.0, nil)
+	assert.NoError(t, err)
+	for _, o := range inCompartmentIt.Offerings {
+		capType := o.Requirements.Get("karpenter.sh/capacity-type").Any()
+		if capType == corev1.CapacityTypeOnDemand && o.Zone() == testZonePHXAD1 {
+			assert.False(t, o.Available,
+				"on-demand PHX-AD-1 offering should be unavailable for the quota-affected compartment")
+		} else {
+			assert.True(t, o.Available, "offering %s/%s should remain available", capType, o.Zone())
+		}
+	}
+
+	// A NodeClass launching into a different compartment must not be affected by the
+	// compartment-scoped quota failure.
+	otherCompartmentIt := newIt()
+	nodeClassOther := &ociv1beta1.OCINodeClass{}
+	nodeClassOther.Spec.NodeCompartmentId = lo.ToPtr(otherCompartment)
+	err = p.setOfferings(context.Background(), otherCompartmentIt, nodeClassOther, sa, true, 1.0, nil)
+	assert.NoError(t, err)
+	for _, o := range otherCompartmentIt.Offerings {
+		assert.True(t, o.Available,
+			"a compartment-scoped quota failure must not suppress offerings for another compartment (%s/%s)",
+			o.Requirements.Get("karpenter.sh/capacity-type").Any(), o.Zone())
+	}
 }
 
 func TestSetOfferings_Prices(t *testing.T) {
@@ -1370,9 +1525,9 @@ func TestSetOfferings_NoPreemptibleSpotIfTaintMissing(t *testing.T) {
 	var hasOnDemand, hasSpot bool
 	for _, o := range it.Offerings {
 		switch o.Requirements.Get("karpenter.sh/capacity-type").Any() {
-		case "on-demand":
+		case corev1.CapacityTypeOnDemand:
 			hasOnDemand = true
-		case "spot":
+		case testCapacityTypeSpot:
 			hasSpot = true
 		}
 	}
@@ -2669,5 +2824,123 @@ func TestGetMaxVnicAttachmentsForShape(t *testing.T) {
 			got := p.getMaxVnicAttachmentsForShape(context.Background(), shape, tt.ocpu)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// TestListInstanceTypes_NoDeadlockWithConcurrentWriter is a regression test for the silent
+// reconcile hang where the leader pod stopped doing work for ~30h without crashing or logging.
+//
+// ListInstanceTypes acquires p.lock.RLock for its whole duration and, deep in its call chain
+// (decorateInstanceType / setOfferings), used to re-acquire p.lock.RLock. sync.RWMutex forbids
+// recursive read-locking: once a writer (refreshShapes/reloadConfigFile, which fire on a ~24h
+// timer) calls p.lock.Lock and blocks waiting for the outer reader, every subsequent RLock --
+// including the nested one from the goroutine that already holds the outer RLock -- blocks to
+// avoid writer starvation. The outer reader then waits forever on its own nested RLock while the
+// writer waits forever on the outer reader: a permanent deadlock that wedges every controller
+// calling ListInstanceTypes.
+//
+// This test drives many concurrent ListInstanceTypes readers against a writer that repeatedly
+// grabs the write lock (as refreshShapes does). With the recursive RLock it deadlocks and the
+// watchdog fires; with the fix it completes quickly.
+func TestListInstanceTypes_NoDeadlockWithConcurrentWriter(t *testing.T) {
+	makeProvider := func() *DefaultProvider {
+		return &DefaultProvider{
+			shapeAdMap: map[string]*ShapeAndAd{
+				"VM.Standard.E3.8": {
+					Shape: &ocicore.Shape{
+						Shape:              lo.ToPtr("VM.Standard.E3.8"),
+						IsFlexible:         lo.ToPtr(false),
+						Ocpus:              lo.ToPtr(float32(8)),
+						MemoryInGBs:        lo.ToPtr(float32(64)),
+						MaxVnicAttachments: lo.ToPtr(4),
+					},
+					Ads: []string{"tenancy:PHX-AD-1", "tenancy:PHX-AD-2"},
+				},
+			},
+			shapeToPrice: map[string]*ShapePriceInfo{
+				"VM.STANDARD.E3.8": {ShapeName: lo.ToPtr("VM.Standard.E3.8"), OcpuUnitPrice: 0.05,
+					MemoryUnitPrice: 0.01, DiskUnitPrice: 0},
+			},
+			preemptibleShapes: PreemptibleShapes{"VM.STANDARD.E3": "VM.Standard.E3"},
+		}
+	}
+
+	nc := &ociv1beta1.OCINodeClass{
+		Spec: ociv1beta1.OCINodeClassSpec{
+			VolumeConfig: &ociv1beta1.VolumeConfig{
+				BootVolumeConfig: &ociv1beta1.BootVolumeConfig{
+					ImageConfig: &ociv1beta1.ImageConfig{ImageType: ociv1beta1.OKEImage},
+				},
+			},
+			NetworkConfig: &ociv1beta1.NetworkConfig{
+				PrimaryVnicConfig: &ociv1beta1.SimpleVnicConfig{
+					SubnetAndNsgConfig: &ociv1beta1.SubnetAndNsgConfig{
+						SubnetConfig: &ociv1beta1.SubnetConfig{SubnetId: lo.ToPtr("ocid1.subnet.oc1..x")},
+					},
+				},
+			},
+		},
+	}
+
+	p := makeProvider()
+
+	const (
+		readers          = 8
+		iterationsPerGor = 2000
+	)
+
+	done := make(chan struct{})
+	stopWriter := make(chan struct{})
+	writerDone := make(chan struct{})
+	// readersWg tracks only the readers: the writer runs until stopWriter is closed, so it must
+	// not be part of the completion wait or it would never let wg.Wait return.
+	var readersWg sync.WaitGroup
+
+	// Writer goroutine: mimics refreshShapes/reloadConfigFile taking p.lock.Lock periodically.
+	// The brief pause keeps the writer from starving readers (the real writers fire on a ~24h
+	// timer) while still frequently entering the "writer pending" state that triggers the old
+	// recursive-RLock deadlock.
+	go func() {
+		defer close(writerDone)
+		for {
+			select {
+			case <-stopWriter:
+				return
+			default:
+			}
+			p.lock.Lock()
+			// emulate the writers swapping the shared maps under the write lock
+			p.shapeAdMap = makeProvider().shapeAdMap
+			p.lock.Unlock()
+			time.Sleep(200 * time.Microsecond)
+		}
+	}()
+
+	// Reader goroutines: call ListInstanceTypes concurrently.
+	for i := 0; i < readers; i++ {
+		readersWg.Add(1)
+		go func() {
+			defer readersWg.Done()
+			for j := 0; j < iterationsPerGor; j++ {
+				its, err := p.ListInstanceTypes(context.Background(), nc, make([]v1.Taint, 0))
+				require.NoError(t, err)
+				require.NotEmpty(t, its)
+			}
+		}()
+	}
+
+	go func() {
+		readersWg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		close(stopWriter)
+		<-writerDone
+	case <-time.After(30 * time.Second):
+		close(stopWriter)
+		t.Fatal("ListInstanceTypes deadlocked with a concurrent writer: " +
+			"recursive p.lock.RLock in the ListInstanceTypes call chain")
 	}
 }


### PR DESCRIPTION
# Description

When a NodePool runs out of host capacity, OCI Karpenter previously returned a generic `CloudProvider.CreateError` from `Create`. Core Karpenter only deletes and reschedules a NodeClaim on an `InsufficientCapacityError`, so on a `CreateError` the NodeClaim stuck to the same (exhausted) NodePool/offering and retried in a tight loop, producing retry storms and 429 throttling, with no fallback to other capacity types or NodePools.

This change makes host-capacity exhaustion behave correctly across three layers:
1. **Classify pool-wide exhaustion as insufficient capacity.** When every launch attempt is consumed and at least one failed with an out-of-host-capacity error (non-capacity launch errors still return early), `CloudProvider.Create` now returns `cloudprovider.NewInsufficientCapacityError`. This lets core Karpenter delete + reschedule the NodeClaim, enabling cross-NodePool fallback.
2. **Add an unavailable-offerings cache.** A new TTL cache (`pkg/cache/unavailableofferings.go`) records `(shape, AD/zone, capacity-type)` offerings observed to be out of capacity. `LaunchInstance` marks offerings unavailable on capacity errors, and the instance-type provider gates offering availability (`Available=false`) when listing instance types. This drives spot→on-demand fallback within a NodePool and prevents the scheduler from immediately re-selecting dead offerings until the entry expires. The TTL is configurable via `--unavailable-offerings-ttl-seconds` (default 180s / 3 minutes).
3. **Stop blindly retrying out-of-capacity at the SDK layer.** `oci.IsRetryable` now treats an HTTP 500 that is an "Out of host capacity" error as non-retryable, so the capacity-fallback logic handles it instead of the SDK amplifying the host-capacity shortage and contributing to 429s.'

Fixes #33 #51

EDIT: Also added a fix for a deadlock issue, see https://github.com/aniekgul/karpenter-provider-oci/pull/3 for details.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Unit and integration tests added to code.

## Live cluster test

In a OKE cluster in ca-toronto-1

### Setup 

Create two node pools, one with an instance type that is highly unlikely to be available and another with lots of room.

```
  exp-fallback-arm-spot:
    enabled: true
    capacity_type: spot
    architecture: arm64
    shapes: [VM.Standard.A1.Flex]
    # Pin to a full A1 host (max 80 OCPU / 512 GB). The shape is offered in the
    # region so Karpenter still attempts a launch, but a near-empty A1 host on
    # spot almost never exists -> launch fails for insufficient capacity.
    shape_configs:
      - { ocpus: 80, memory_gibs: 512 }
    taints:
      - *taint_exp_fallback
      - *taint_oke_preemptible
    labels:
      experiment-fallback: "true"
    weight: 100

  exp-fallback-amd64-od:
    enabled: true
    capacity_type: on-demand
    shapes:
      - VM.Standard.E3.Flex
      - VM.Standard.E4.Flex
      - VM.Standard.E5.Flex
    taints:
      - *taint_exp_fallback
    labels:
      experiment-fallback: "true"
    weight: 90
```

### Execution

Using the current karpenter version 1.1.0, create a deployment that targets both:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: karpenter-fallback-test
  namespace: default
  labels:
    app: karpenter-fallback-test
    experiment: karpenter-fallback
spec:
  replicas: 1
  selector:
    matchLabels:
      app: karpenter-fallback-test
  template:
    metadata:
      labels:
        app: karpenter-fallback-test
        experiment: karpenter-fallback
    spec:
      # Target only the two experiment pools.
      nodeSelector:
        experiment-fallback: "true"
      tolerations:
        # Isolating taint shared by both experiment pools.
        - key: experiment-karpenter-fallback
          operator: Equal
          value: "true"
          effect: NoSchedule
        # KPO spot taint on the ARM-spot pool — required so Karpenter considers
        # that (higher-weight) pool first.
        - key: oci.oraclecloud.com/oke-is-preemptible
          operator: Exists
          effect: NoSchedule
      containers:
        - name: pause
          # Multi-arch so the pod is valid on both the arm64 and amd64 pools.
          image: registry.k8s.io/pause:3.9
          resources:
            requests:
              cpu: "2"
              memory: 4Gi
            limits:
              cpu: "2"
              memory: 4Gi
```

The pod will stay pending.

Logs from the current Karpenter version: (Only included important fields)
```
LaunchInstance start - name: ci-ca-toronto-1-exp-fallback-arm-spot-rf4wn

LaunchInstance failed - error: Error returned by Compute Service. Http Status Code: 500. Error Code: InternalError. ... Message: Out of host capacity. Operation Name: LaunchInstance

Reconciler error - error: launching nodeclaim, creating nodeclaim, cannot create node after trying all instance types

(Launch failure loop starts)
LaunchInstance failed - error: Error returned by Compute Service. Http Status Code: 500. Error Code: InternalError. ... Message: Out of host capacity. Operation Name: LaunchInstance

```

Delete the deployment and update to the version from this branch.

Recreate the deployment and now it should schedule on a new node from the second pool.

Logs from this branch's version:
```
LaunchInstance start - name: ci-ca-toronto-1-exp-fallback-arm-spot-jk6mu

LaunchInstance failed - error: Error returned by Compute Service. Http Status Code: 500. Error Code: InternalError. ... Message: Out of host capacity. Operation Name: LaunchInstance

all instance types exhausted due to insufficient capacity - error: Error returned by Compute Service. Http Status Code: 500. Error Code: InternalError. ... Message: Out of host capacity. Operation Name: LaunchInstance

failed launching nodeclaim - error: insufficient capacity, all instance types exhausted due to insufficient capacity,

deleted nodeclaim - name: ci-ca-toronto-1-exp-fallback-arm-spot-jk6mu

created nodeclaim - name: ci-ca-toronto-1-exp-fallback-amd64-od-q5nz5

LaunchInstance success - name: ci-ca-toronto-1-exp-fallback-amd64-od-q5nz5
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules