### PR TITLE
docs: update consolidateAfter usage examples

### DIFF
--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -37,7 +37,7 @@ spec:
   disruption:
     budgets:
       - nodes: 5%
-    consolidateAfter: 60m
+    consolidateAfter: 10m
     consolidationPolicy: WhenEmpty
   limits:
     cpu: 64
@@ -101,7 +101,7 @@ spec:
           - Drifted
         schedule: "@daily" # customize for your needs (see https://karpenter.sh/docs/concepts/disruption/)
         duration: 10m
-    consolidateAfter: 60m
+    consolidateAfter: 10m
     consolidationPolicy: WhenEmpty
   limits:
     cpu: 64


### PR DESCRIPTION
#Title
docs: update consolidateAfter usage examples

#Description
Updates the consolidateAfter value in the usage guide examples from 60m to 10m.

#Changes

Updated both NodePool examples in docs/guide/usage.md
Changed disruption.consolidateAfter from 60m to 10m
Testing

Documentation-only change; no code tests run.