### PR TITLE
Handle OCI out of host capacity errors

### DIFF
--- a/pkg/cloudprovider/cloud_provider.go
+++ b/pkg/cloudprovider/cloud_provider.go
@@ -170,6 +170,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *corev1.NodeClaim)
 
 	var inst *instance.InstanceInfo
 	var selectedInstanceType *instancetype.OciInstanceType
+	var capacityErr error
 
 	// try launch until all instance types are consumed.
 	for _, instanceType := range instanceTypes {
@@ -199,6 +200,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *corev1.NodeClaim)
 			lg.Error(err, "cannot launch instance")
 			// TODO in capacity reservation case, what error will we get if there is no capacity?
 			if instance.IsNoCapacityError(err) {
+				capacityErr = err
 				continue
 			}
 			return nil, cloudprovider.NewCreateError(fmt.Errorf("launch instance failure, %w", err),
@@ -213,6 +215,11 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *corev1.NodeClaim)
 	if inst == nil {
 		errMsg := "cannot create node after trying all instance types"
 		finalErr := errors.New(errMsg)
+		if capacityErr != nil {
+			finalErr = fmt.Errorf("%s, %w", errMsg, capacityErr)
+			lg.Error(finalErr, "")
+			return nil, cloudprovider.NewInsufficientCapacityError(finalErr)
+		}
 		lg.Error(finalErr, "")
 		return nil, cloudprovider.NewCreateError(finalErr, "LaunchInstanceFailed", errMsg)
 	}

--- a/pkg/cloudprovider/cloud_provider_test.go
+++ b/pkg/cloudprovider/cloud_provider_test.go
@@ -629,6 +629,34 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			Expect(launchCount).To(Equal(2))
 		})
 
+		It("should return insufficient capacity when launch exhausts out of host capacity errors", func() {
+			launchCount := 0
+			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+				kubeClient:    kubeClient,
+				instanceTypes: []*instancetype.OciInstanceType{instanceA, instanceB},
+				imageProvider: &FakeImageProvider{
+					ResolveImageForShapeFn: func(_ context.Context, _ *v1beta1.ImageConfig,
+						_ string) (*image.ImageResolveResult, error) {
+						return imageResult, nil
+					},
+				},
+				instanceProvider: &FakeInstanceProvider{
+					LaunchInstanceFn: func(_ context.Context, _ *v1.NodeClaim, _ *v1beta1.OCINodeClass,
+						_ *instancetype.OciInstanceType, _ *image.ImageResolveResult, _ *network.NetworkResolveResult,
+						_ *kms.KmsKeyResolveResult, _ *placement.Proposal) (*instance.InstanceInfo, error) {
+						launchCount++
+						return nil, errors.New("Out of host capacity in selected AD")
+					},
+				},
+			})
+
+			_, err := cp.Create(context.Background(), nodeClaim)
+			Expect(cloudprovider.IsInsufficientCapacityError(err)).To(BeTrue())
+			var createErr *cloudprovider.CreateError
+			Expect(errors.As(err, &createErr)).To(BeFalse())
+			Expect(launchCount).To(Equal(2))
+		})
+
 		It("should return a create error when launch fails with a non-capacity error", func() {
 			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
 				kubeClient:    kubeClient,

--- a/pkg/oci/errors.go
+++ b/pkg/oci/errors.go
@@ -106,7 +106,14 @@ func IsNotFound(err error) bool {
 }
 
 func IsOutOfHostCapacity(err error) bool {
-	serviceErr, ok := common.IsServiceError(err)
+	if err == nil {
+		return false
+	}
 
-	return ok && strings.Contains(serviceErr.GetMessage(), OutOfHostCapacity)
+	serviceErr, ok := common.IsServiceError(err)
+	if ok {
+		return strings.Contains(serviceErr.GetMessage(), OutOfHostCapacity)
+	}
+
+	return strings.Contains(err.Error(), OutOfHostCapacity)
 }

--- a/pkg/oci/errors_test.go
+++ b/pkg/oci/errors_test.go
@@ -218,11 +218,14 @@ func TestIsNotFound(t *testing.T) {
 }
 
 func TestIsOutOfHostCapacity(t *testing.T) {
+	assert.False(t, IsOutOfHostCapacity(nil))
+
 	assert.True(t, IsOutOfHostCapacity(fakeServiceError{
 		httpStatus: http.StatusConflict,
 		code:       "IncorrectState",
 		message:    "Out of host capacity in selected AD",
 	}))
+	assert.True(t, IsOutOfHostCapacity(stderrs.New("Out of host capacity in selected AD")))
 
 	assert.False(t, IsOutOfHostCapacity(fakeServiceError{
 		httpStatus: http.StatusConflict,

--- a/pkg/providers/instance/provider.go
+++ b/pkg/providers/instance/provider.go
@@ -201,6 +201,9 @@ func (p *DefaultProvider) LaunchInstance(ctx context.Context,
 
 	resp, err := p.computeClient.LaunchInstance(ctx, launchRequest)
 	if err != nil {
+		if oci.IsOutOfHostCapacity(err) {
+			return nil, NoCapacityError{}
+		}
 		return nil, err
 	}
 
@@ -251,7 +254,11 @@ func (p *DefaultProvider) LaunchInstance(ctx context.Context,
 					return nil, errors.New("work-request failed")
 				}
 				if len(errResp.Items) > 0 && errResp.Items[0].Message != nil {
-					return nil, errors.New(*errResp.Items[0].Message)
+					err = errors.New(*errResp.Items[0].Message)
+					if oci.IsOutOfHostCapacity(err) {
+						return nil, NoCapacityError{}
+					}
+					return nil, err
 				}
 				return nil, fmt.Errorf("work-request failed %s", wrID)
 			}

--- a/pkg/providers/instance/provider_test.go
+++ b/pkg/providers/instance/provider_test.go
@@ -1086,6 +1086,16 @@ func TestProvider_LaunchInstance_FailurePaths(t *testing.T) {
 		fc.LaunchErr = nil
 	})
 
+	t.Run("out of host capacity launch error returns no capacity", func(t *testing.T) {
+		fc.LaunchErr = errors.New("Out of host capacity in selected AD")
+		_, err := p.LaunchInstance(context.TODO(), baseClaim, baseNodeClass,
+			&instancetype.OciInstanceType{
+				Shape: "VM.Standard.E4.Flex"}, imgRes, netRes, nil, pp)
+		require.Error(t, err)
+		assert.Equal(t, NoCapacityError{}, err)
+		fc.LaunchErr = nil
+	})
+
 }
 
 func TestProvider_Cached_Wrappers_Negative(t *testing.T) {
@@ -1279,6 +1289,65 @@ func TestProvider_LaunchInstance_WorkRequestSuccess(t *testing.T) {
 	assert.NotNil(t, inst)
 	assert.Equal(t, "ocid1.instance.oc1..new", *inst.Id)
 	assert.Greater(t, callCount, 0, "expected GetWorkRequest called at least once")
+}
+
+func TestProvider_LaunchInstance_WorkRequestOutOfHostCapacity(t *testing.T) {
+	fc := &fakes.FakeCompute{}
+	fwr := &fakes.FakeWorkRequest{}
+
+	fc.OnLaunch = func(ctx context.Context, r ocicore.LaunchInstanceRequest) (ocicore.LaunchInstanceResponse, error) {
+		return ocicore.LaunchInstanceResponse{
+			Instance: ocicore.Instance{Id: lo.ToPtr("ocid1.instance.oc1..new")},
+			Etag:     lo.ToPtr("etag-new"),
+			RawResponse: &http.Response{
+				StatusCode: 200,
+				Header: http.Header{
+					"Opc-Work-Request-Id": []string{"wr-launch-123"},
+				},
+			},
+		}, nil
+	}
+
+	fwr.GetResp = ociwr.GetWorkRequestResponse{
+		WorkRequest: ociwr.WorkRequest{
+			Status:       ociwr.WorkRequestStatusFailed,
+			TimeFinished: &common.SDKTime{Time: time.Now()},
+			TimeStarted:  &common.SDKTime{Time: time.Now()},
+		},
+	}
+	fwr.ListErrorsResp = ociwr.ListWorkRequestErrorsResponse{
+		Items: []ociwr.WorkRequestError{{
+			Code:      lo.ToPtr("InternalError"),
+			Message:   lo.ToPtr("Out of host capacity in selected AD"),
+			Timestamp: &common.SDKTime{Time: time.Now()},
+		}},
+	}
+
+	imdsp, err := instancemeta.NewProvider(context.TODO(), "10.0.0.1", []byte("CA"), ipV4SingleStack)
+	require.NoError(t, err)
+	p := &DefaultProvider{
+		computeClient:        fc,
+		workRequestClient:    fwr,
+		instanceMetaProvider: imdsp,
+		clusterCompartmentId: "ocid1.compartment.oc1..parent",
+		launchTimeoutVM:      10 * time.Minute,
+		launchTimeoutBM:      20 * time.Minute,
+		pollInterval:         time.Millisecond,
+	}
+
+	it := &instancetype.OciInstanceType{
+		InstanceType: cloudprovider.InstanceType{
+			Name:      "VM.Standard.E4.Flex",
+			Offerings: cloudprovider.Offerings{makeOfferingWithCapType(corev1.CapacityTypeOnDemand)},
+		},
+		Shape: "VM.Standard.E4.Flex",
+	}
+
+	_, err = p.LaunchInstance(context.TODO(), minimalNodeClaim(), minimalNodeClass(), it, minimalImageResolve(),
+		minimalNetworkResolve(), nil, minimalPlacement())
+	require.Error(t, err)
+	assert.Equal(t, NoCapacityError{}, err)
+	assert.Equal(t, 1, fwr.ListCount.Get())
 }
 
 func TestProvider_LaunchInstance_Timeout(t *testing.T) {


### PR DESCRIPTION
## Description
- Map OCI `Out of host capacity` launch failures to Karpenter `InsufficientCapacityError`.
- Normalize direct `LaunchInstance` and failed work-request capacity errors to `NoCapacityError`.
- Preserve non-capacity launch failures as `CreateError` / `LaunchInstanceFailed`.
