### PR TITLE
fix: add GPU capacity and pricing for OCI GPU shapes

### DIFF
--- a/pkg/providers/instancetype/provider.go
+++ b/pkg/providers/instancetype/provider.go
@@ -51,6 +51,9 @@ const (
 	PreemptibleTaintKey = "oci.oraclecloud.com/oke-is-preemptible"
 	NvidiaGpuTaintKey   = "nvidia.com/gpu"
 	AmdGpuTaintKey      = "amd.com/gpu"
+
+	NvidiaGpuResourceName = v1.ResourceName("nvidia.com/gpu")
+	AmdGpuResourceName    = v1.ResourceName("amd.com/gpu")
 )
 
 type Provider interface {
@@ -479,8 +482,26 @@ func setCapacity(it *OciInstanceType, shape *ocicore.Shape, ocpu float32, gbs fl
 			*class.Spec.VolumeConfig.BootVolumeConfig.SizeInGBs, resource.Giga)
 	}
 
+	if gpuCount := gpuCount(shape); gpuCount > 0 {
+		res[gpuResourceName(shape)] = *resource.NewQuantity(int64(gpuCount), resource.DecimalSI)
+	}
+
 	it.InstanceType.Capacity = res
-	// TBD: add Nvme, gpu, vnic attachments
+	// TBD: add Nvme, vnic attachments
+}
+
+func gpuResourceName(shape *ocicore.Shape) v1.ResourceName {
+	if shape != nil && IsAmdGpuShape(*shape) {
+		return AmdGpuResourceName
+	}
+	return NvidiaGpuResourceName
+}
+
+func gpuCount(shape *ocicore.Shape) int {
+	if shape == nil || shape.Gpus == nil {
+		return 0
+	}
+	return *shape.Gpus
 }
 
 func vcpu(shape *ocicore.Shape, ocpu float32) float32 {
@@ -727,6 +748,10 @@ func (p *DefaultProvider) calculatePrices(shape *ocicore.Shape, ocpu float32, gb
 
 	if si == nil {
 		return 0, false
+	}
+
+	if gpuCount := gpuCount(shape); gpuCount > 0 {
+		return si.OcpuUnitPrice * float64(gpuCount), true
 	}
 
 	cpuDiscount := float64(1)

--- a/pkg/providers/instancetype/provider_test.go
+++ b/pkg/providers/instancetype/provider_test.go
@@ -274,7 +274,16 @@ func TestIsArmGpuBmDenseFlexAndArch(t *testing.T) {
 	armShape := ocicore.Shape{Shape: lo.ToPtr("VM.Standard.A1.Flex"), IsFlexible: lo.ToPtr(true)}
 	amdShape := ocicore.Shape{Shape: lo.ToPtr("VM.Standard.E4.Flex"), IsFlexible: lo.ToPtr(true)}
 	bmShape := ocicore.Shape{Shape: lo.ToPtr("BM.Standard.E4.128")}
-	gpuShape := ocicore.Shape{Shape: lo.ToPtr("VM.GPU.A10.1"), Gpus: lo.ToPtr(1)}
+	gpuShape := ocicore.Shape{
+		Shape:          lo.ToPtr("VM.GPU.A10.1"),
+		Gpus:           lo.ToPtr(1),
+		GpuDescription: lo.ToPtr("NVIDIA A10"),
+	}
+	amdGpuShape := ocicore.Shape{
+		Shape:          lo.ToPtr("BM.GPU.MI300X.8"),
+		Gpus:           lo.ToPtr(8),
+		GpuDescription: lo.ToPtr("AMD MI300X"),
+	}
 	denseIo := ocicore.Shape{Shape: lo.ToPtr("VM.Standard3.DenseIO64"), LocalDisksTotalSizeInGBs: lo.ToPtr[float32](1024)}
 
 	assert.True(t, IsArmShape(armShape))
@@ -282,6 +291,9 @@ func TestIsArmGpuBmDenseFlexAndArch(t *testing.T) {
 
 	assert.True(t, IsGpuShape(gpuShape))
 	assert.False(t, IsGpuShape(amdShape))
+	assert.False(t, IsAmdGpuShape(gpuShape))
+	assert.True(t, IsAmdGpuShape(amdGpuShape))
+	assert.False(t, IsAmdGpuShape(amdShape))
 
 	assert.True(t, IsBmShape(*bmShape.Shape))
 	assert.False(t, IsBmShape(*amdShape.Shape))
@@ -296,6 +308,119 @@ func TestIsArmGpuBmDenseFlexAndArch(t *testing.T) {
 	// Compute cluster supported shape list is upper-cased internally
 	assert.True(t, p.isComputeClusterSupportedShape("BM.GPU.H100.8"))
 	assert.False(t, p.isComputeClusterSupportedShape("VM.Standard.E4.Flex"))
+}
+
+func TestSetCapacity_GPUResources(t *testing.T) {
+	nc := &ociv1beta1.OCINodeClass{
+		Spec: ociv1beta1.OCINodeClassSpec{
+			VolumeConfig: &ociv1beta1.VolumeConfig{
+				BootVolumeConfig: &ociv1beta1.BootVolumeConfig{},
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		shape           ocicore.Shape
+		wantResource    v1.ResourceName
+		wantGPUQuantity *resource.Quantity
+	}{
+		{
+			name: "nvidia gpu shape",
+			shape: ocicore.Shape{
+				Shape:      lo.ToPtr("VM.GPU.A10.2"),
+				IsFlexible: lo.ToPtr(false),
+				Gpus:       lo.ToPtr(2),
+			},
+			wantResource:    NvidiaGpuResourceName,
+			wantGPUQuantity: resource.NewQuantity(2, resource.DecimalSI),
+		},
+		{
+			name: "amd gpu shape",
+			shape: ocicore.Shape{
+				Shape:          lo.ToPtr("BM.GPU.MI300X.8"),
+				IsFlexible:     lo.ToPtr(false),
+				Gpus:           lo.ToPtr(8),
+				GpuDescription: lo.ToPtr("AMD MI300X"),
+			},
+			wantResource:    AmdGpuResourceName,
+			wantGPUQuantity: resource.NewQuantity(8, resource.DecimalSI),
+		},
+		{
+			name: "non gpu shape",
+			shape: ocicore.Shape{
+				Shape:      lo.ToPtr("VM.Standard.E4.Flex"),
+				IsFlexible: lo.ToPtr(true),
+			},
+		},
+		{
+			name: "gpu shape name with missing gpu count",
+			shape: ocicore.Shape{
+				Shape:      lo.ToPtr("BM.GPU.H100.8"),
+				IsFlexible: lo.ToPtr(false),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			it := &OciInstanceType{}
+
+			setCapacity(it, &tt.shape, 2, 8, nc, ipV4SingleStack)
+
+			assert.Contains(t, it.Capacity, v1.ResourceCPU)
+			assert.Contains(t, it.Capacity, v1.ResourceMemory)
+			assert.Contains(t, it.Capacity, v1.ResourcePods)
+			if tt.wantGPUQuantity == nil {
+				assert.NotContains(t, it.Capacity, NvidiaGpuResourceName)
+				assert.NotContains(t, it.Capacity, AmdGpuResourceName)
+				return
+			}
+			assert.True(t, tt.wantGPUQuantity.Equal(it.Capacity[tt.wantResource]))
+		})
+	}
+}
+
+func TestGpuResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		shape ocicore.Shape
+		want  v1.ResourceName
+	}{
+		{
+			name: "amd gpu description uses amd gpu resource",
+			shape: ocicore.Shape{
+				Shape:          lo.ToPtr("BM.GPU.MI300X.8"),
+				Gpus:           lo.ToPtr(8),
+				GpuDescription: lo.ToPtr("AMD MI300X"),
+			},
+			want: AmdGpuResourceName,
+		},
+		{
+			name: "a10 uses nvidia gpu resource",
+			shape: ocicore.Shape{
+				Shape:          lo.ToPtr("VM.GPU.A10.2"),
+				Gpus:           lo.ToPtr(2),
+				GpuDescription: lo.ToPtr("NVIDIA A10"),
+			},
+			want: NvidiaGpuResourceName,
+		},
+		{
+			name: "h100 uses nvidia gpu resource",
+			shape: ocicore.Shape{
+				Shape:          lo.ToPtr("BM.GPU.H100.8"),
+				Gpus:           lo.ToPtr(8),
+				GpuDescription: lo.ToPtr("NVIDIA H100"),
+			},
+			want: NvidiaGpuResourceName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, gpuResourceName(&tt.shape))
+		})
+	}
 }
 
 // instance_type.go tests
@@ -1243,6 +1368,41 @@ func TestCalculatePrices(t *testing.T) {
 			wantOk:    true,
 			wantPrice: 1.04, // 8*0.05 + 64*0.01 + 0 = 1.04
 		},
+		{
+			name: "nvidia gpu shape uses gpu unit price",
+			shape: &ocicore.Shape{
+				Shape: lo.ToPtr("VM.GPU.A10.2"),
+				Gpus:  lo.ToPtr(2),
+			},
+			ocpu:      24,
+			mem:       240,
+			baseline:  ociv1beta1.BASELINE_1_8,
+			wantOk:    true,
+			wantPrice: 4,
+		},
+		{
+			name: "amd gpu shape uses gpu unit price",
+			shape: &ocicore.Shape{
+				Shape: lo.ToPtr("BM.GPU.MI300X.8"),
+				Gpus:  lo.ToPtr(8),
+			},
+			ocpu:      224,
+			mem:       2048,
+			baseline:  ociv1beta1.BASELINE_1_2,
+			wantOk:    true,
+			wantPrice: 48,
+		},
+		{
+			name: "gpu shape price falls back without gpu count",
+			shape: &ocicore.Shape{
+				Shape: lo.ToPtr("VM.GPU.A10.2"),
+			},
+			ocpu:      24,
+			mem:       240,
+			baseline:  ociv1beta1.BASELINE_1_1,
+			wantOk:    true,
+			wantPrice: 48,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1252,6 +1412,11 @@ func TestCalculatePrices(t *testing.T) {
 				p.shapeToPrice = map[string]*ShapePriceInfo{
 					"VM.STANDARD.E4.FLEX": {ShapeName: lo.ToPtr("VM.Standard.E4.Flex"), OcpuUnitPrice: 0.05,
 						MemoryUnitPrice: 0.01, DiskUnitPrice: 0.1},
+					"VM.GPU.A10.2": {ShapeName: lo.ToPtr("VM.GPU.A10.2"), OcpuUnitPrice: 2},
+					"BM.GPU.MI300X.8": {
+						ShapeName:     lo.ToPtr("BM.GPU.MI300X.8"),
+						OcpuUnitPrice: 6,
+					},
 				}
 			})
 			price, ok := p.calculatePrices(tt.shape, tt.ocpu, tt.mem, tt.baseline)

--- a/pkg/providers/instancetype/shape.go
+++ b/pkg/providers/instancetype/shape.go
@@ -30,6 +30,15 @@ func IsGpuShape(shape ocicore.Shape) bool {
 	return shape.Gpus != nil && *shape.Gpus > 0
 }
 
+func IsAmdGpuShape(shape ocicore.Shape) bool {
+	if shape.GpuDescription == nil {
+		return false
+	}
+
+	u := strings.ToUpper(*shape.GpuDescription)
+	return strings.Contains(u, string(ShapeSerialAmd))
+}
+
 func IsBmShape(shape string) bool {
 	u := strings.ToUpper(shape)
 


### PR DESCRIPTION
# Description

- expose GPU capacity using the NVIDIA or AMD resource name for OCI GPU shapes
- calculate GPU shape pricing from the GPU count
- add coverage for NVIDIA and AMD capacity plus GPU pricing

Fixes https://github.com/oracle/karpenter-provider-oci/issues/31

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Deployment
```
spec:
  progressDeadlineSeconds: 600
  replicas: 3
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: inflate
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: inflate
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: karpenter.sh/nodepool
                operator: In
                values:
                - nodepool-test-new
      containers:
      - image: phx.ocir.io/odx-mockcustomer/pause:3.5
        imagePullPolicy: IfNotPresent
        name: inflate
        resources:
          limits:
            nvidia.com/gpu: "1"
        securityContext:
          allowPrivilegeEscalation: false
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext:
        fsGroup: 2000
        runAsGroup: 3000
        runAsUser: 1000
      terminationGracePeriodSeconds: 0
      tolerations:
      - effect: NoSchedule
        key: nvidia.com/gpu
        operator: Exists
```
Nodeclaim
```
k get nodeclaims -owide
NAME                      TYPE           CAPACITY    ZONE       NODE         READY   AGE   IMAGEID                                                                            ID                                                                                    NODEPOOL            NODECLASS        DRIFTED
nodepool-test-new-9lqrr   VM.GPU.A10.2   on-demand   PHX-AD-1   10.0.10.72   True    28m   ocid1.image.oc1.phx.aaaaaaaawwgppws3m2qlitwi7fwsn3a5iz5oz5zu5umwuvtvzm5d5j7fe5lq   ocid1.instance.oc1.phx.anyhqljth4gjgpycqz7jp25p64wtdffzcqh7xonlxnzvm7ainn6guqbsmopq   nodepool-test-new   nodeclass-test
nodepool-test-new-kjntd   VM.GPU.A10.1   on-demand   PHX-AD-1   10.0.10.61   True    26m   ocid1.image.oc1.phx.aaaaaaaawwgppws3m2qlitwi7fwsn3a5iz5oz5zu5umwuvtvzm5d5j7fe5lq   ocid1.instance.oc1.phx.anyhqljth4gjgpycldlf2epxk2ksrpc275c47vrhovzz7jkjiml2btjqez3q   nodepool-test-new   nodeclass-test
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
