### PR TITLE
fix: prevent recursive read lock deadlock

### DIFF
--- a/pkg/providers/instancetype/provider.go
+++ b/pkg/providers/instancetype/provider.go
@@ -310,11 +310,7 @@ func (p *DefaultProvider) decorateInstanceType(ctx context.Context, it *OciInsta
 	setCapacity(it, shape, ocpu, memoryInGbs, nodeClass, p.ipFamilies)
 	setOverhead(it, shape, ocpu, memoryInGbs, nodeClass)
 
-	basePrice, priceAvailable := func() (float64, bool) {
-		p.lock.RLock()
-		defer p.lock.RUnlock()
-		return p.calculatePrices(shape, ocpu, memoryInGbs, cpuBaseline)
-	}()
+	basePrice, priceAvailable := p.calculatePrices(shape, ocpu, memoryInGbs, cpuBaseline)
 
 	vnicAvailable := true
 	secondVnicsNum := -1
@@ -734,7 +730,7 @@ func (p *DefaultProvider) reloadConfigFile(ctx context.Context) error {
 
 func (p *DefaultProvider) calculatePrices(shape *ocicore.Shape, ocpu float32, gbs float32,
 	baseline ociv1beta1.BaselineOcpuUtilization) (float64, bool) {
-	// this method is called within a read lock
+	// The caller must hold p.lock for reading.
 	shapeUp := strings.ToUpper(*shape.Shape)
 	si, ok := p.shapeToPrice[shapeUp]
 	if !ok {
@@ -772,6 +768,7 @@ func (p *DefaultProvider) calculatePrices(shape *ocicore.Shape, ocpu float32, gb
 }
 
 func (p *DefaultProvider) isPreemptibleShape(shape string) bool {
+	// The caller must hold p.lock for reading.
 	shapeUp := strings.ToUpper(shape)
 	if _, ok := p.preemptibleShapes[shapeUp]; ok {
 		return true
@@ -788,6 +785,7 @@ func (p *DefaultProvider) isPreemptibleShape(shape string) bool {
 
 // isComputeClusterSupportedShape checks if a shape is supported for compute clusters
 func (p *DefaultProvider) isComputeClusterSupportedShape(shapeName string) bool {
+	// The caller must hold p.lock for reading.
 	// https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/compute-clusters.htm
 	return lo.Contains(p.computeClusterShapes, strings.ToUpper(shapeName))
 }
@@ -803,11 +801,7 @@ func (p *DefaultProvider) setOfferings(ctx context.Context, it *OciInstanceType,
 	offerings := makeOnDemandOffering(*shapeAndAd.Shape.Shape, shapeAndAd.Ads, basePrice, available,
 		placementRestrictFunc)
 
-	isPreemptible := func() bool {
-		p.lock.RLock()
-		defer p.lock.RUnlock()
-		return p.isPreemptibleShape(*shapeAndAd.Shape.Shape)
-	}()
+	isPreemptible := p.isPreemptibleShape(*shapeAndAd.Shape.Shape)
 
 	var capResAdMap map[capacityreservation.CapacityReserveIdAndAd]map[string]capacityreservation.ShapeAvailability
 	if len(nodeClass.Spec.CapacityReservationConfigs) > 0 {
@@ -910,6 +904,7 @@ func (p *DefaultProvider) ListInstanceTypes(ctx context.Context,
 	nodeClass *ociv1beta1.OCINodeClass, taints []v1.Taint) ([]*OciInstanceType, error) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
+	// Helpers in this call tree read provider state under this lock and must not reacquire it.
 
 	// for each shape, we return offering
 	instanceTypes := make([]*OciInstanceType, 0)

--- a/pkg/providers/instancetype/provider_test.go
+++ b/pkg/providers/instancetype/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/coreos/go-semver/semver"
@@ -643,6 +644,101 @@ func TestCalculatePricesAndOfferings(t *testing.T) {
 	}
 	assert.GreaterOrEqual(t, onDemand, 2)
 	assert.GreaterOrEqual(t, spot, 2)
+}
+
+func TestDecorateInstanceType_DoesNotDeadlock(t *testing.T) {
+	p := &DefaultProvider{
+		shapeToPrice: map[string]*ShapePriceInfo{
+			"VM.STANDARD.E4.FLEX": {
+				ShapeName: lo.ToPtr("VM.Standard.E4.Flex"), OcpuUnitPrice: 0.05,
+				MemoryUnitPrice: 0.01, DiskUnitPrice: 0,
+			},
+		},
+		preemptibleShapes: PreemptibleShapes{"VM.STANDARD.E4": "VM.Standard.E4"},
+	}
+	shape := &ocicore.Shape{
+		Shape:       lo.ToPtr("VM.Standard.E4.Flex"),
+		Ocpus:       lo.ToPtr(float32(4)),
+		MemoryInGBs: lo.ToPtr(float32(32)),
+		BillingType: ocicore.ShapeBillingTypePaid,
+	}
+	shapeAndAd := &ShapeAndAd{Shape: shape, Ads: []string{"tenancy:PHX-AD-1"}}
+	nodeClass := &ociv1beta1.OCINodeClass{
+		Spec: ociv1beta1.OCINodeClassSpec{
+			VolumeConfig: &ociv1beta1.VolumeConfig{
+				BootVolumeConfig: &ociv1beta1.BootVolumeConfig{},
+			},
+			NetworkConfig: &ociv1beta1.NetworkConfig{},
+		},
+	}
+	instanceType := &OciInstanceType{
+		InstanceType: cloudprovider.InstanceType{Name: "VM.Standard.E4.Flex"},
+		Shape:        "VM.Standard.E4.Flex",
+		Ocpu:         lo.ToPtr(float32(4)),
+		MemoryInGbs:  lo.ToPtr(float32(32)),
+	}
+
+	// Model ListInstanceTypes holding its outer read lock while a refresher queues for the write lock.
+	p.lock.RLock()
+	outerLockHeld := true
+	defer func() {
+		if outerLockHeld {
+			p.lock.RUnlock()
+		}
+	}()
+
+	writerDone := make(chan struct{})
+	writerAcquired := false
+	go func() {
+		p.lock.Lock()
+		writerAcquired = true
+		p.lock.Unlock()
+		close(writerDone)
+	}()
+
+	writerQueued := false
+	queueDeadline := time.Now().Add(time.Second)
+	for time.Now().Before(queueDeadline) {
+		if !p.lock.TryRLock() {
+			writerQueued = true
+			break
+		}
+		p.lock.RUnlock()
+		time.Sleep(time.Millisecond)
+	}
+	if !writerQueued {
+		p.lock.RUnlock()
+		outerLockHeld = false
+		<-writerDone
+		t.Fatal("writer did not queue behind the outer read lock")
+	}
+
+	decorateDone := make(chan error, 1)
+	go func() {
+		decorateDone <- p.decorateInstanceType(context.Background(), instanceType, nodeClass, shapeAndAd,
+			[]v1.Taint{preemptibleTaintNoSchedule})
+	}()
+
+	select {
+	case err := <-decorateDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		// Release and drain all blocked goroutines before failing the test.
+		p.lock.RUnlock()
+		outerLockHeld = false
+		<-writerDone
+		<-decorateDone
+		t.Fatal("decorateInstanceType recursively acquired the provider read lock")
+	}
+
+	p.lock.RUnlock()
+	outerLockHeld = false
+	select {
+	case <-writerDone:
+		assert.True(t, writerAcquired)
+	case <-time.After(time.Second):
+		t.Fatal("queued writer did not complete after releasing the outer read lock")
+	}
 }
 
 func TestFinalizeRequirements(t *testing.T) {


### PR DESCRIPTION
# Description

`ListInstanceTypes` holds the provider read lock while its helper chain reads shared pricing and shape metadata. `decorateInstanceType` and `setOfferings` reacquired that read lock. When a refresh writer queued between those acquisitions, Go writer preference blocked the nested reader, while the outer reader could not release its lock, deadlocking provisioning.

This change removes the two nested read-lock acquisitions, documents caller-owned lock requirements, and adds a deterministic regression test that queues a writer while the outer read lock is held.

The temporary accelerated refresh intervals and unrelated workflow updates used during reproduction are not included.

Fixes #49

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go test -count=100 -run TestDecorateInstanceType_DoesNotDeadlock ./pkg/providers/instancetype`
- [x] `golangci-lint run`
- [x] Accelerated OKE validation with 100ms metadata and 5s shape refreshes: a stress NodeClaim became Ready, `GetInstanceTypes` advanced by 2,003 calls, all 6,766 metadata and 130 shape refresh starts completed, and the controller remained Ready with zero restarts.

- Kubernetes version: v1.35.2
- OKE version: managed OKE cluster
- Karpenter Provider OCI version: fixed test image based on the current provider source
- Installation method (`helm`, manifests, local run): existing cluster deployment

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing relevant tests pass locally with my changes