### PR TITLE
fix: correct spot and reserved offering prices

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,22 +61,22 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to Docker
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/pkg/providers/instancetype/provider.go
+++ b/pkg/providers/instancetype/provider.go
@@ -43,6 +43,7 @@ import (
 
 const (
 	minK8sMinorForMultiFlex = 31
+	spotPriceFactor         = 0.5
 
 	MemoryAvailable = "memory.available"
 	NodeFSAvailable = "nodefs.available"
@@ -385,22 +386,22 @@ func isValidOcpuOptions(ocpuOptions *ocicore.ShapeOcpuOptions) bool {
 	return ocpuOptions != nil && ocpuOptions.Min != nil
 }
 
-func makeOnDemandOffering(shapeName string, ads []string, price float64, available bool,
+func makeOnDemandOffering(shapeName string, ads []string, basePrice float64, available bool,
 	computeClusterRestrictFunc func(string, string) bool) []*cloudprovider.Offering {
 	return lo.Map(ads, func(ad string, _ int) *cloudprovider.Offering {
-		return makeOffering(ad, price, corev1.CapacityTypeOnDemand,
+		return makeOffering(ad, basePrice, corev1.CapacityTypeOnDemand,
 			available && computeClusterRestrictFunc(shapeName, ad))
 	})
 }
 
-func makeSpotOffering(ads []string, base float64) []*cloudprovider.Offering {
+func makeSpotOffering(ads []string, basePrice float64) []*cloudprovider.Offering {
 	return lo.Map(ads, func(ad string, _ int) *cloudprovider.Offering {
-		return makeOffering(ad, base*0.5, corev1.CapacityTypeSpot, true)
+		return makeOffering(ad, basePrice*spotPriceFactor, corev1.CapacityTypeSpot, true)
 	})
 }
 
 // makeReservedOffering can produce many offering, based on combination of capReservation, ad or individual fd or mix.
-func makeReservedOffering(price float64,
+func makeReservedOffering(basePrice float64,
 	capResAdMap map[capacityreservation.CapacityReserveIdAndAd]map[string]capacityreservation.ShapeAvailability,
 ) []*cloudprovider.Offering {
 	offerings := make([]*cloudprovider.Offering, 0)
@@ -413,7 +414,7 @@ func makeReservedOffering(price float64,
 				avail = 0
 			}
 
-			offering := makeOffering(capResIdAndAd.Ad, price*0.85, corev1.CapacityTypeReserved, avail != 0)
+			offering := makeOffering(capResIdAndAd.Ad, basePrice, corev1.CapacityTypeReserved, avail != 0)
 			offering.ReservationCapacity = avail
 
 			// extend scheduling requirement
@@ -819,7 +820,7 @@ func (p *DefaultProvider) setOfferings(ctx context.Context, it *OciInstanceType,
 	// Preemptible capacity does not support burstable instances, nor capacity reservation.
 	if available && isPreemptible && !IsBurstableShape(it) && len(capResAdMap) == 0 {
 		if hasPreemptibleTaints {
-			offerings = append(offerings, makeSpotOffering(shapeAndAd.Ads, basePrice*0.5)...)
+			offerings = append(offerings, makeSpotOffering(shapeAndAd.Ads, basePrice)...)
 		} else {
 			log.FromContext(ctx).V(1).Info(fmt.Sprintf("Missing '%s' taints for preemptible shape '%s'",
 				PreemptibleTaintKey, *shapeAndAd.Shape.Shape))
@@ -828,7 +829,7 @@ func (p *DefaultProvider) setOfferings(ctx context.Context, it *OciInstanceType,
 
 	if available && capResAdMap != nil {
 		// be noticed capacity reservation does not support burstable && preemptible
-		offerings = append(offerings, makeReservedOffering(basePrice*0.85, capResAdMap)...)
+		offerings = append(offerings, makeReservedOffering(basePrice, capResAdMap)...)
 	}
 
 	it.Offerings = append(it.Offerings, offerings...)

--- a/pkg/providers/instancetype/provider_test.go
+++ b/pkg/providers/instancetype/provider_test.go
@@ -55,6 +55,25 @@ var (
 	ipV6DualStack   = []network.IpFamily{network.IPv4, network.IPv6}
 )
 
+type fakeCapacityReservationProvider struct {
+	results []capacityreservation.ResolveResult
+	err     error
+}
+
+func (f *fakeCapacityReservationProvider) ResolveCapacityReservations(context.Context,
+	[]*ociv1beta1.CapacityReservationConfig,
+) ([]capacityreservation.ResolveResult, error) {
+	return f.results, f.err
+}
+
+func (f *fakeCapacityReservationProvider) MarkCapacityReservationUsed(*ocicore.Instance) {}
+
+func (f *fakeCapacityReservationProvider) MarkCapacityReservationReleased(*ocicore.Instance) {}
+
+func (f *fakeCapacityReservationProvider) SyncCapacityReservation(context.Context, string) error {
+	return nil
+}
+
 func TestCalculatePrices_BaselinesAndPrefix(t *testing.T) {
 	p := &DefaultProvider{
 		shapeToPrice: map[string]*ShapePriceInfo{
@@ -1012,11 +1031,13 @@ func TestMakeReservedOffering(t *testing.T) {
 				Ad:          "tenancy:PHX-AD-1"},
 		},
 	}
-	offerings := makeReservedOffering(1.0, capResAdMap)
+	const basePrice = 1.0
+	offerings := makeReservedOffering(basePrice, capResAdMap)
 	// Should include at least one offering for AD-1 with capacity 6 (10-4)
 	found := false
 	for _, o := range offerings {
 		if o.Requirements.Get(v1.LabelTopologyZone).Any() == "PHX-AD-1" && o.ReservationCapacity == 6 {
+			assert.Equal(t, basePrice, o.Price)
 			found = true
 			break
 		}
@@ -1222,6 +1243,105 @@ func TestSetOfferings_PreemptibleSpotAdded(t *testing.T) {
 	}
 	assert.True(t, hasOnDemand, "expected on-demand offerings")
 	assert.True(t, hasSpot, "expected spot offerings for preemptible non-burstable shape")
+}
+
+func TestSetOfferings_Prices(t *testing.T) {
+	const (
+		ad        = "tenancy:PHX-AD-1"
+		basePrice = 1.0
+		shapeName = "VM.Standard.E4.Flex"
+	)
+
+	reservedNodeClass := &ociv1beta1.OCINodeClass{
+		Spec: ociv1beta1.OCINodeClassSpec{
+			CapacityReservationConfigs: []*ociv1beta1.CapacityReservationConfig{{
+				CapacityReservationId: lo.ToPtr("ocid1.capacityreservation.oc1..reserved"),
+			}},
+		},
+	}
+	reservedProvider := &fakeCapacityReservationProvider{
+		results: []capacityreservation.ResolveResult{{
+			Ocid: "ocid1.capacityreservation.oc1..reserved",
+			Ad:   ad,
+			ShapeAvailabilities: []capacityreservation.ShapeAvailability{{
+				Ad: ad, Shape: shapeName, Total: 1,
+			}},
+		}},
+	}
+
+	tests := []struct {
+		name              string
+		preemptible       bool
+		taints            []v1.Taint
+		nodeClass         *ociv1beta1.OCINodeClass
+		reservationSource capacityreservation.Provider
+		wantPrices        map[string]float64
+	}{
+		{
+			name:      "on-demand uses base price",
+			nodeClass: &ociv1beta1.OCINodeClass{},
+			wantPrices: map[string]float64{
+				corev1.CapacityTypeOnDemand: basePrice,
+			},
+		},
+		{
+			name:        "spot applies discount once",
+			preemptible: true,
+			taints:      []v1.Taint{preemptibleTaintNoSchedule},
+			nodeClass:   &ociv1beta1.OCINodeClass{},
+			wantPrices: map[string]float64{
+				corev1.CapacityTypeOnDemand: basePrice,
+				corev1.CapacityTypeSpot:     basePrice * spotPriceFactor,
+			},
+		},
+		{
+			name:        "spot is absent without required taint",
+			preemptible: true,
+			nodeClass:   &ociv1beta1.OCINodeClass{},
+			wantPrices: map[string]float64{
+				corev1.CapacityTypeOnDemand: basePrice,
+			},
+		},
+		{
+			name:              "reserved running instance uses base price",
+			nodeClass:         reservedNodeClass,
+			reservationSource: reservedProvider,
+			wantPrices: map[string]float64{
+				corev1.CapacityTypeOnDemand: basePrice,
+				corev1.CapacityTypeReserved: basePrice,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preemptibleShapes := PreemptibleShapes{}
+			if tt.preemptible {
+				preemptibleShapes["VM.STANDARD.E4"] = "VM.Standard.E4"
+			}
+			p := &DefaultProvider{
+				preemptibleShapes:           preemptibleShapes,
+				capacityReservationProvider: tt.reservationSource,
+			}
+			it := &OciInstanceType{
+				InstanceType: cloudprovider.InstanceType{Name: shapeName},
+				Shape:        shapeName,
+			}
+			shapeAndAd := &ShapeAndAd{
+				Shape: &ocicore.Shape{Shape: lo.ToPtr(shapeName)},
+				Ads:   []string{ad},
+			}
+
+			err := p.setOfferings(context.Background(), it, tt.nodeClass, shapeAndAd, true, basePrice, tt.taints)
+			require.NoError(t, err)
+			require.Len(t, it.Offerings, len(tt.wantPrices))
+
+			gotPrices := lo.SliceToMap(it.Offerings, func(offering *cloudprovider.Offering) (string, float64) {
+				return offering.CapacityType(), offering.Price
+			})
+			assert.Equal(t, tt.wantPrices, gotPrices)
+		})
+	}
 }
 
 func TestSetOfferings_NoPreemptibleSpotIfTaintMissing(t *testing.T) {


### PR DESCRIPTION
# Description

Fixes #48.

This change makes each offering builder own its capacity-type pricing policy. Spot offerings apply the 0.5 factor exactly once, while running instances launched against reserved capacity use the standard base price. It also adds table-driven regression coverage for on-demand, spot, missing spot taint, and reserved prices.

The commit also refreshes the pinned Docker action versions in the release workflow.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `go test -mod=mod ./pkg/providers/instancetype`
- [x] `go test -mod=mod ./pkg/cloudprovider`
- [x] `git diff --check`

- Kubernetes version: N/A (unit tests)
- OKE version: N/A (unit tests)
- Karpenter Provider OCI version: main
- Installation method (`helm`, manifests, local run): local unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules