### PR TITLE
Fix an issue that securityAttributes json field always added to VNIC request object even it is not set in the OCINodeClass

### DIFF
--- a/pkg/providers/instance/provider.go
+++ b/pkg/providers/instance/provider.go
@@ -532,7 +532,9 @@ func buildCreateVnicDetails(network *network.NetworkResolveResult,
 			c.SkipSourceDestCheck = lo.ToPtr(true)
 		}
 
-		c.SecurityAttributes = npn.MapValueStringToMapValueInterface(primaryVnicDetails.SecurityAttributes)
+		if len(primaryVnicDetails.SecurityAttributes) > 0 {
+			c.SecurityAttributes = npn.MapValueStringToMapValueInterface(primaryVnicDetails.SecurityAttributes)
+		}
 		c.Ipv6AddressIpv6SubnetCidrPairDetails =
 			npn.ToOciCoreIpvAddressCidrPair(primaryVnicDetails.Ipv6AddressIpv6SubnetCidrPairDetails)
 	}

--- a/pkg/providers/instance/provider_test.go
+++ b/pkg/providers/instance/provider_test.go
@@ -566,7 +566,7 @@ func TestProvider_BuildCreateVnicDetails(t *testing.T) {
 		}
 
 		if tc.securityAttributes == nil {
-			assert.True(t, len(result.SecurityAttributes) == 0)
+			assert.True(t, result.SecurityAttributes == nil)
 		} else {
 			for k, v := range tc.securityAttributes {
 				for k1, value1 := range v {


### PR DESCRIPTION
# Description
Fix an issue that securityAttributes json field always added to VNIC request object even it is not set in the OCINodeClass


Fixes # (issue) 
https://github.com/oracle/karpenter-provider-oci/issues/28

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Manual Testing
-- Before
<img width="1616" height="200" alt="Screenshot 2026-07-06 at 16 35 55" src="https://github.com/user-attachments/assets/9f727cd2-a48a-4839-9f7a-862daeed3278" />

-- After
<img width="1666" height="202" alt="Screenshot 2026-07-06 at 16 36 20" src="https://github.com/user-attachments/assets/66707748-e32c-4948-b049-979adc6662eb" />

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules