### PR TITLE
docs: add OCI API rate limiter guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See [Installation](docs/guide/installation.md).
   - [Configure IAM Policies for KPO to manage OCI resources](docs/guide/configure-iam-policies.md)
   - [Install KPO Helm Chart](docs/guide/installation-using-helm.md)
 - [Helm Chart Reference](docs/reference/helm-chart.md)
+- [OCI API Rate Limiter](docs/guide/rate-limiter.md)
 - [OCI v1beta1 API](docs/reference/v1beta1-api-raw.md)
 - [Scheduling Labels](docs/guide/scheduling-labels.md)
 - [Usage](docs/guide/usage.md)

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -251,11 +251,11 @@ settings:
     # -- Disable the OCI client-side rate limiter.
     disable: true
     # -- Read QPS for the OCI client-side rate limiter. 0 uses the built-in default.
-    qpsRead: 0
+    qpsRead: 0.0
     # -- Read burst for the OCI client-side rate limiter. 0 uses the built-in default.
     burstRead: 0
     # -- Write QPS for the OCI client-side rate limiter. 0 uses the built-in default.
-    qpsWrite: 0
+    qpsWrite: 0.0
     # -- Write burst for the OCI client-side rate limiter. 0 uses the built-in default.
     burstWrite: 0
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -3,6 +3,7 @@
 - Implements the standard Karpenter cloud-provider interface (aligned with upstream **Karpenter v1.11.1**), enabling dynamic node scaling to meet workload scheduling demands and optimization requirements.
 - Supports drift detection to keep nodes launched by KPO up-to-date.
 - Provides opt-in and configurable node repair policies.
+- Provides an optional, configurable client-side [OCI API rate limiter](rate-limiter.md) with separate controls for read and write requests.
 - Supports upstream `NodeOverlay` when `settings.featureGates.nodeOverlay=true`, allowing operators to add scheduling-time capacity overlays or price adjustments for selected instance types and node pools.
 - Supports upstream static node pools when `settings.featureGates.staticCapacity=true`, enabling fixed-replica `NodePool.spec.replicas` workflows in addition to demand-driven provisioning.
 - Supports a wide range of OCI cloud-specific features through `OCINodeClass`, including:

--- a/docs/guide/rate-limiter.md
+++ b/docs/guide/rate-limiter.md
@@ -1,0 +1,188 @@
+# OCI API Rate Limiter
+
+Karpenter Provider OCI (KPO) includes an optional client-side rate limiter for OCI API requests. The limiter smooths bursts of requests from KPO before they reach OCI services, helping reduce server-side throttling during controller reconciliation, node launches, and node terminations.
+
+The rate limiter is available in KPO v1.2.0 and later. It is disabled by default so that upgrading KPO does not change request throughput until an operator explicitly enables it.
+
+## How it works
+
+When enabled, KPO creates two token buckets:
+
+- A **read** bucket for OCI get and list operations.
+- A **write** bucket for OCI operations that change resources.
+
+Each request waits for a token from its bucket before KPO calls the OCI SDK. A bucket can issue requests at its configured queries-per-second (QPS) rate and can temporarily exceed that steady rate up to its burst capacity. For example, a QPS of `10` with a burst of `3` permits up to three immediately available requests, after which tokens are replenished at ten per second.
+
+The limiter is local to each KPO process. If more than one KPO replica is actively making OCI requests, each replica has its own read and write buckets. Choose values with the aggregate traffic from the deployment and any other clients using the same OCI service limits in mind.
+
+Client-side rate limiting does not replace OCI service limits or the OCI SDK retry policy. OCI can still return `429 TooManyRequests` or other throttling responses because limits can vary by service, operation, tenancy, or region.
+
+## Default behavior
+
+The Helm chart defaults to:
+
+```yaml
+settings:
+  rateLimiter:
+    disable: true
+    qpsRead: 0.0
+    burstRead: 0
+    qpsWrite: 0.0
+    burstWrite: 0
+```
+
+`disable: true` bypasses client-side limiting. When the limiter is enabled, a rate or burst value of `0` selects the built-in default:
+
+| Traffic class | Built-in QPS | Built-in burst |
+| --- | ---: | ---: |
+| Read | 20 | 5 |
+| Write | 20 | 5 |
+
+All rate and burst values must be greater than or equal to zero. QPS values may be fractional; burst values must be integers.
+
+## Enable the rate limiter
+
+To enable the limiter with the built-in rates, add the following settings to the values file used for the KPO release:
+
+```yaml
+settings:
+  rateLimiter:
+    disable: false
+    qpsRead: 0.0
+    burstRead: 0
+    qpsWrite: 0.0
+    burstWrite: 0
+```
+
+Apply the updated configuration:
+
+```shell
+helm upgrade karpenter karpenter-provider-oci/karpenter \
+  --version <chart-version> \
+  --namespace <karpenter-namespace> \
+  --values <path-to-values.yaml>
+```
+
+You can also enable the built-in defaults with a Helm command-line override:
+
+```shell
+helm upgrade karpenter karpenter-provider-oci/karpenter \
+  --version <chart-version> \
+  --namespace <karpenter-namespace> \
+  --reuse-values \
+  --set settings.rateLimiter.disable=false
+```
+
+After the KPO pods restart, each pod logs the effective configuration in a message similar to:
+
+```text
+OCI rate limiter is enabled readQPS=20 readBurst=5 writeQPS=20 writeBurst=5
+```
+
+## Configure custom limits
+
+Set read and write values independently when the workload has different traffic profiles. The following example allows more read traffic than write traffic:
+
+```yaml
+settings:
+  rateLimiter:
+    disable: false
+    qpsRead: 10
+    burstRead: 5
+    qpsWrite: 5
+    burstWrite: 2
+```
+
+The Helm values map to KPO flags and environment variables as follows:
+
+| Helm value | KPO flag | Environment variable | Description |
+| --- | --- | --- | --- |
+| `settings.rateLimiter.disable` | `--disable-rate-limiter` | `DISABLE_RATE_LIMITER` | Set to `false` to enable the limiter. |
+| `settings.rateLimiter.qpsRead` | `--rate-limit-qps-read` | `RATE_LIMIT_QPS_READ` | Steady read request rate. `0` uses 20 QPS. |
+| `settings.rateLimiter.burstRead` | `--rate-limit-burst-read` | `RATE_LIMIT_BURST_READ` | Maximum read burst. `0` uses 5. |
+| `settings.rateLimiter.qpsWrite` | `--rate-limit-qps-write` | `RATE_LIMIT_QPS_WRITE` | Steady write request rate. `0` uses 20 QPS. |
+| `settings.rateLimiter.burstWrite` | `--rate-limit-burst-write` | `RATE_LIMIT_BURST_WRITE` | Maximum write burst. `0` uses 5. |
+
+When running KPO without the Helm chart, configure either flags or their corresponding environment variables. An explicitly provided flag takes precedence over its environment variable.
+
+## Requests covered by the limiter
+
+The two buckets are shared across the supported OCI clients within a KPO process; they are not separate per OCI service.
+
+Read-limited operations include:
+
+- Compute queries for instances, shapes, images, image compatibility, VNIC attachments, boot volume attachments, capacity reservations, compute clusters, and related list operations.
+- Block Volume `GetBootVolume`.
+- Virtual Cloud Network queries for subnets, VNICs, and network security groups.
+- Identity queries for compartments and availability domains.
+- Work Request queries for status and errors.
+- Cluster Placement Group get and list operations.
+- Key Management `GetKey`.
+
+Write-limited operations include:
+
+- Compute `LaunchInstance`.
+- Compute `TerminateInstance`.
+
+## Tune the limits
+
+Start with the built-in values and adjust gradually using observed controller behavior and OCI service responses.
+
+- Lower QPS when KPO or other automation frequently receives OCI throttling responses.
+- Keep the burst small when short request spikes trigger throttling.
+- Increase read limits when discovery or reconciliation is delayed and OCI is not throttling the requests.
+- Increase write limits cautiously when node launches or terminations queue behind the client-side limiter.
+- Account for every active KPO replica because the limits apply per process, not globally across the deployment.
+
+Avoid setting a very low burst relative to concurrent controller activity. A small bucket can serialize requests and increase provisioning or termination latency even when the QPS value appears sufficient.
+
+## Verify the configuration
+
+Check the rate-limiter environment variables rendered into the deployment:
+
+```shell
+kubectl -n <karpenter-namespace> get deployment karpenter \
+  -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' \
+  | grep -E '^(DISABLE_RATE_LIMITER|RATE_LIMIT_)'
+```
+
+Check the startup log for the effective values:
+
+```shell
+kubectl -n <karpenter-namespace> logs deployment/karpenter \
+  | grep 'OCI rate limiter is'
+```
+
+The log reports either `OCI rate limiter is disabled` or the enabled read and write settings. When a request cannot obtain a token because its context is canceled or expires, KPO logs `OCI rate limiter wait failed` with the OCI operation and traffic mode.
+
+## Disable the rate limiter
+
+Set `disable` back to `true` and upgrade the release:
+
+```yaml
+settings:
+  rateLimiter:
+    disable: true
+```
+
+Disabling the limiter makes both buckets always allow requests. The OCI SDK retry policy and OCI service-side throttling still apply.
+
+## Troubleshooting
+
+### The startup log says the limiter is disabled
+
+Confirm that the effective Helm values contain `settings.rateLimiter.disable: false` and that the deployment has `DISABLE_RATE_LIMITER=false`. A stale values file or `--reuse-values` can retain the previous setting.
+
+### KPO still receives `429 TooManyRequests`
+
+The configured rate may be above an OCI service limit, other clients may be consuming the same limit, or multiple KPO processes may be contributing traffic. Reduce the relevant QPS and burst values, then compare the frequency of throttling responses and controller latency.
+
+### Provisioning or termination became slower
+
+The write bucket covers both launch and terminate requests. If OCI is not returning throttling responses, increase `qpsWrite` or `burstWrite` incrementally. Also check whether multiple node operations are waiting concurrently.
+
+### Discovery or reconciliation became slower
+
+Most discovery calls use the shared read bucket. If OCI is not returning throttling responses, increase `qpsRead` or `burstRead` incrementally.
+
+For the complete Helm value reference, see [Helm Chart Reference](../reference/helm-chart.md).

--- a/docs/reference/helm-chart.md
+++ b/docs/reference/helm-chart.md
@@ -86,8 +86,8 @@ A Helm chart for Karpenter provider OCI
 | settings.rateLimiter.burstRead | int | `0` | Read burst for the OCI client-side rate limiter. 0 uses the built-in default. |
 | settings.rateLimiter.burstWrite | int | `0` | Write burst for the OCI client-side rate limiter. 0 uses the built-in default. |
 | settings.rateLimiter.disable | bool | `true` | Disable the OCI client-side rate limiter. |
-| settings.rateLimiter.qpsRead | int | `0` | Read QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
-| settings.rateLimiter.qpsWrite | int | `0` | Write QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
+| settings.rateLimiter.qpsRead | float | `0` | Read QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
+| settings.rateLimiter.qpsWrite | float | `0` | Write QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
 | settings.unavailableOfferingsTTLSeconds | int | `180` | How long, in seconds, an offering observed to be out of host capacity is treated as unavailable before Karpenter retries it. Lower values retry exhausted offerings sooner; higher values reduce repeated launch attempts (and OCI throttling) against capacity that is unlikely to recover quickly. Set to 0 to disable the unavailable-offerings cache entirely, in which case offerings are never marked unavailable and Karpenter does not route around capacity-exhausted offerings. |
 | settings.vcnCompartmentId | string | `""` | [required] Cluster's VCN compartment OCID. |
 | strategy | object | `{"rollingUpdate":{"maxUnavailable":1}}` | Strategy for updating the pod. |


### PR DESCRIPTION
## Summary

Adds a detailed guide for the OCI client-side rate limiter introduced in [#24](https://github.com/oracle/karpenter-provider-oci/pull/24).

The guide explains how operators can enable, configure, verify, tune, and troubleshoot the KPO rate limiter.

## Changes

- Documented the separate read and write token buckets.
- Documented the built-in QPS and burst defaults.
- Added Helm values, CLI flags, and environment-variable mappings.
- Added configuration examples for default and custom limits.
- Listed the OCI operations covered by each limiter.
- Added guidance for tuning limits and handling OCI throttling.
- Added rollout verification and troubleshooting commands.
- Added links to the guide from the README and features page.