### PR TITLE
Gate service limit unavailable offerings cache

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -168,6 +168,10 @@ spec:
             - name: UNAVAILABLE_OFFERINGS_TTL_SECONDS
               value: "{{ .Values.settings.unavailableOfferingsTTLSeconds }}"
             {{- end }}
+            {{- if not (kindIs "invalid" .Values.settings.enableUnavailableOfferingsOnServiceLimitExceeded) }}
+            - name: ENABLE_UNAVAILABLE_OFFERINGS_ON_SERVICE_LIMIT_EXCEEDED
+              value: "{{ .Values.settings.enableUnavailableOfferingsOnServiceLimitExceeded }}"
+            {{- end }}
             {{- with .Values.settings.flexibleShapeConfigs }}
             - name: FLEXIBLE_SHAPE_CONFIGS
               value: {{ . | toJson | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -275,6 +275,9 @@ settings:
   # marked unavailable and Karpenter does not route around capacity-exhausted offerings.
   unavailableOfferingsTTLSeconds: 180
 
+  # -- When true, OCI LimitExceeded and QuotaExceeded failures mark the offering unavailable. Disabled by default.
+  enableUnavailableOfferingsOnServiceLimitExceeded: false
+
   # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
   # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features
   featureGates:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,6 +59,7 @@ func main() {
 		op.BlockStorageProvider,
 		op.NpnProvider,
 		ociOptions.RepairPolicies,
+		ociOptions.EnableUnavailableOfferingsOnServiceLimitExceeded,
 		op.Elected(),
 	)
 

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -237,6 +237,17 @@ Notes:
 - Set `replicas` high enough for the number of ADs or FDs you expect the workload to use.
 - The `labelSelector` must match the pod labels, or the scheduler will not calculate skew against the intended pod set.
 - Supported scheduling labels are documented in [Scheduling Labels](scheduling-labels.md).
+
+### How can Karpenter fall back when an OCI service limit or compartment quota is exceeded?
+
+By default, an OCI `LimitExceeded` or `QuotaExceeded` launch failure is returned immediately. To have Karpenter temporarily treat the failed offering as unavailable and try another compatible offering or NodePool, enable the Helm setting:
+
+```yaml
+settings:
+  enableUnavailableOfferingsOnServiceLimitExceeded: true
+```
+
+The unavailable-offerings cache is enabled by default for 180 seconds. Keep `settings.unavailableOfferingsTTLSeconds` greater than zero for cache-based fallback; adjust it if you want failed offerings retried sooner or later. This setting does not increase OCI limits or quotas—review and raise the applicable limit or quota when necessary.
   
 ### How can I list OKE images compatible with my OKE cluster?
 

--- a/docs/reference/helm-chart.md
+++ b/docs/reference/helm-chart.md
@@ -89,6 +89,7 @@ A Helm chart for Karpenter provider OCI
 | settings.rateLimiter.qpsRead | int | `0` | Read QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
 | settings.rateLimiter.qpsWrite | int | `0` | Write QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
 | settings.unavailableOfferingsTTLSeconds | int | `180` | How long, in seconds, an offering observed to be out of host capacity is treated as unavailable before Karpenter retries it. Lower values retry exhausted offerings sooner; higher values reduce repeated launch attempts (and OCI throttling) against capacity that is unlikely to recover quickly. Set to 0 to disable the unavailable-offerings cache entirely, in which case offerings are never marked unavailable and Karpenter does not route around capacity-exhausted offerings. |
+| settings.enableUnavailableOfferingsOnServiceLimitExceeded | bool | `false` | When true, OCI LimitExceeded and QuotaExceeded failures mark the offering unavailable. Disabled by default. |
 | settings.vcnCompartmentId | string | `""` | [required] Cluster's VCN compartment OCID. |
 | strategy | object | `{"rollingUpdate":{"maxUnavailable":1}}` | Strategy for updating the pod. |
 | terminationGracePeriodSeconds | string | `nil` | Override the default termination grace period for the pod. |
@@ -96,4 +97,3 @@ A Helm chart for Karpenter provider OCI
 | topologySpreadConstraints | list | `[{"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"DoNotSchedule"}]` | Topology spread constraints to increase the controller resilience by distributing pods across the cluster zones. If an explicit label selector is not provided one will be created from the pod selector labels. |
 | volumeMounts | list | `[]` | Additional volume mounts on the controller container. |
 | volumes | list | `[]` | Additional volumes on the controller Deployment. |
-

--- a/pkg/cloudprovider/cloud_provider.go
+++ b/pkg/cloudprovider/cloud_provider.go
@@ -59,13 +59,15 @@ type CloudProvider struct {
 	blockStorageProvider        blockstorage.Provider
 	npnProvider                 npn.Provider
 	repairPolicies              []cloudprovider.RepairPolicy
+	enableServiceLimitFallback  bool
 	initialized                 bool
 }
 
 func New(ctx context.Context, client client.Client, itp instancetype.Provider, imgp image.Provider,
 	nwp network.Provider, kkp kms.Provider, ip instance.Provider, pp placement.Provider,
 	cp capacityreservation.Provider, bsp blockstorage.Provider, npn npn.Provider,
-	repairPolicies []cloudprovider.RepairPolicy, startAsync <-chan struct{}) (*CloudProvider, error) {
+	repairPolicies []cloudprovider.RepairPolicy, enableServiceLimitFallback bool,
+	startAsync <-chan struct{}) (*CloudProvider, error) {
 	c := &CloudProvider{
 		kubeClient:                  client,
 		instanceTypeProvider:        itp,
@@ -77,6 +79,7 @@ func New(ctx context.Context, client client.Client, itp instancetype.Provider, i
 		capacityReservationProvider: cp,
 		blockStorageProvider:        bsp,
 		npnProvider:                 npn,
+		enableServiceLimitFallback:  enableServiceLimitFallback,
 	}
 
 	if len(repairPolicies) > 0 {
@@ -205,10 +208,9 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *corev1.NodeClaim)
 		if err != nil {
 			lg.Error(err, "cannot launch instance")
 			// TODO in capacity reservation case, what error will we get if there is no capacity?
-			// Host-capacity shortage and service-limit/compartment-quota failures are skippable:
-			// move on to the next shape and remember the error so we can surface an
-			// InsufficientCapacityError if every candidate shape is exhausted.
-			if instance.IsSkippableLaunchError(err) {
+			// Host-capacity shortage is always skippable. Service-limit/compartment-quota
+			// failures are skippable only when the service-limit fallback gate is enabled.
+			if instance.IsSkippableLaunchError(err, c.enableServiceLimitFallback) {
 				skipErr = err
 				continue
 			}
@@ -223,8 +225,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *corev1.NodeClaim)
 
 	if inst == nil {
 		// No instance type launched and at least one launch attempt failed due to a skippable
-		// capacity exhaustion (host-capacity shortage or service-limit/compartment-quota;
-		// non-skippable launch errors return earlier). Surface an InsufficientCapacityError so
+		// capacity exhaustion; non-skippable launch errors return earlier. Surface an InsufficientCapacityError so
 		// core Karpenter deletes the NodeClaim and reschedules, enabling fallback to other
 		// offerings / capacity types / NodePools.
 		if skipErr != nil {

--- a/pkg/cloudprovider/cloud_provider_test.go
+++ b/pkg/cloudprovider/cloud_provider_test.go
@@ -122,7 +122,7 @@ var _ = Describe("CloudProvider Integration Tests", func() {
 			cpgProvider))
 		cloudProvider = lo.Must(New(ctx, k8sClient, instancetypeProvider, imageProvider,
 			networkProvider, kmsProvider, instanceProvider, placementProvider,
-			crProvider, bsProvider, npnProvider, nil, fakes.NewDummyChannel()))
+			crProvider, bsProvider, npnProvider, nil, false, fakes.NewDummyChannel()))
 	})
 
 	It("should create nodeclaim with nodeclass hash", func() {
@@ -765,8 +765,9 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 		It("should return insufficient capacity when all instance types hit a service limit", func() {
 			launchCount := 0
 			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
-				kubeClient:    kubeClient,
-				instanceTypes: []*instancetype.OciInstanceType{instanceA, instanceB},
+				kubeClient:                 kubeClient,
+				instanceTypes:              []*instancetype.OciInstanceType{instanceA, instanceB},
+				enableServiceLimitFallback: true,
 				imageProvider: &FakeImageProvider{
 					ResolveImageForShapeFn: func(_ context.Context, _ *v1beta1.ImageConfig,
 						_ string) (*image.ImageResolveResult, error) {
@@ -788,11 +789,40 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			Expect(launchCount).To(Equal(2))
 		})
 
-		It("should fall back to the next shape when one shape hits a service limit", func() {
+		It("should return a create error when service limit fallback is disabled", func() {
 			launchCount := 0
 			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
 				kubeClient:    kubeClient,
 				instanceTypes: []*instancetype.OciInstanceType{instanceA, instanceB},
+				imageProvider: &FakeImageProvider{
+					ResolveImageForShapeFn: func(_ context.Context, _ *v1beta1.ImageConfig,
+						_ string) (*image.ImageResolveResult, error) {
+						return imageResult, nil
+					},
+				},
+				instanceProvider: &FakeInstanceProvider{
+					LaunchInstanceFn: func(_ context.Context, _ *v1.NodeClaim, _ *v1beta1.OCINodeClass,
+						_ *instancetype.OciInstanceType, _ *image.ImageResolveResult, _ *network.NetworkResolveResult,
+						_ *kms.KmsKeyResolveResult, _ *placement.Proposal) (*instance.InstanceInfo, error) {
+						launchCount++
+						return nil, fakeServiceError{statusCode: 400, code: "LimitExceeded", message: "service limit exceeded"}
+					},
+				},
+			})
+
+			_, err := cp.Create(context.Background(), nodeClaim)
+			var createErr *cloudprovider.CreateError
+			Expect(errors.As(err, &createErr)).To(BeTrue())
+			Expect(cloudprovider.IsInsufficientCapacityError(err)).To(BeFalse())
+			Expect(launchCount).To(Equal(1))
+		})
+
+		It("should fall back to the next shape when one shape hits a service limit", func() {
+			launchCount := 0
+			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+				kubeClient:                 kubeClient,
+				instanceTypes:              []*instancetype.OciInstanceType{instanceA, instanceB},
+				enableServiceLimitFallback: true,
 				imageProvider: &FakeImageProvider{
 					ResolveImageForShapeFn: func(_ context.Context, _ *v1beta1.ImageConfig,
 						_ string) (*image.ImageResolveResult, error) {
@@ -920,6 +950,7 @@ type unitTestCloudProviderOptions struct {
 	capacityReservationProvider capacityreservation.Provider
 	npnProvider                 npn.Provider
 	repairPolicies              []cloudprovider.RepairPolicy
+	enableServiceLimitFallback  bool
 }
 
 func newUnitTestCloudProvider(opts unitTestCloudProviderOptions) *CloudProvider {
@@ -945,6 +976,7 @@ func newUnitTestCloudProvider(opts unitTestCloudProviderOptions) *CloudProvider 
 		capacityReservationProvider: &FakeCapacityReservationProvider{},
 		npnProvider:                 &FakeNpnProvider{},
 		repairPolicies:              opts.repairPolicies,
+		enableServiceLimitFallback:  opts.enableServiceLimitFallback,
 	}
 
 	if opts.imageProvider != nil {
@@ -1303,6 +1335,8 @@ var _ = Describe("CloudProvider NodePool Fallback", func() {
 	})
 
 	It("falls back to another NodePool when the preferred pool's launch hits a service limit", func() {
+		cp.enableServiceLimitFallback = true
+
 		// The preferred shape's launch fails with a service-limit (LimitExceeded) error. We emulate
 		// the production LaunchInstance defer by marking the offering unavailable on that error; the
 		// FakeInstanceProvider does not run the real defer. CloudProvider.Create classifies this as an
@@ -1557,6 +1591,8 @@ var _ = Describe("CloudProvider Compartment Scoping", func() {
 	})
 
 	It("keeps a different compartment schedulable when a QuotaExceeded failure is compartment-scoped", func() {
+		cp.enableServiceLimitFallback = true
+
 		// The launch into compartment A fails with QuotaExceeded. Emulate the production
 		// LaunchInstance defer by marking the offering unavailable scoped to compartment A; the
 		// FakeInstanceProvider does not run the real defer. CloudProvider.Create classifies this as an

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -156,7 +156,7 @@ func createOperator(ctx context.Context, coreOp *operator.Operator,
 	instanceProvider := lo.Must(instance.NewProvider(ctx, ociClient, ociClient,
 		ociOptions.ClusterCompartmentId, instanceMetadataProvider, networkProvider,
 		vmTimeout, bmTimeout, ociOptions.InstanceLaunchTimeOutFailOver, instancePollInterval,
-		unavailableOfferings))
+		unavailableOfferings, ociOptions.EnableUnavailableOfferingsOnServiceLimitExceeded))
 
 	imageProvider := lo.Must(image.NewProvider(ctx, clientSet, ociClient,
 		ociOptions.PreBakedImageCompartmentId, "", coreOp.Elected()))

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -26,30 +26,31 @@ import (
 )
 
 type Options struct {
-	ShapeMetaFile                          string
-	ShapeMetaRefreshIntervalHours          int
-	ClusterCompartmentId                   string
-	VcnCompartmentId                       string
-	OciVcnIpNative                         bool
-	PreBakedImageCompartmentId             string
-	ApiserverEndpoint                      string
-	IpFamiliesFlag                         *network.IpFamilyValue
-	OciAuthMethods                         AuthMethod
-	OciProfileName                         string
-	GlobalShapeConfigs                     []ociv1beta1.ShapeConfig
-	RepairPolicies                         []cloudprovider.RepairPolicy
-	InstanceLaunchTimeoutVMMins            int
-	InstanceLaunchTimeoutBMMins            int
-	InstanceOperationPollIntervalInSeconds int
-	InstanceLaunchTimeOutFailOver          bool
-	UnavailableOfferingsTTLSeconds         int
-	DisableRateLimiter                     bool
-	RateLimitQPSRead                       float64
-	RateLimitBurstRead                     int
-	RateLimitQPSWrite                      float64
-	RateLimitBurstWrite                    int
-	setFlags                               map[string]bool
-	parsed                                 bool
+	ShapeMetaFile                                    string
+	ShapeMetaRefreshIntervalHours                    int
+	ClusterCompartmentId                             string
+	VcnCompartmentId                                 string
+	OciVcnIpNative                                   bool
+	PreBakedImageCompartmentId                       string
+	ApiserverEndpoint                                string
+	IpFamiliesFlag                                   *network.IpFamilyValue
+	OciAuthMethods                                   AuthMethod
+	OciProfileName                                   string
+	GlobalShapeConfigs                               []ociv1beta1.ShapeConfig
+	RepairPolicies                                   []cloudprovider.RepairPolicy
+	InstanceLaunchTimeoutVMMins                      int
+	InstanceLaunchTimeoutBMMins                      int
+	InstanceOperationPollIntervalInSeconds           int
+	InstanceLaunchTimeOutFailOver                    bool
+	UnavailableOfferingsTTLSeconds                   int
+	EnableUnavailableOfferingsOnServiceLimitExceeded bool
+	DisableRateLimiter                               bool
+	RateLimitQPSRead                                 float64
+	RateLimitBurstRead                               int
+	RateLimitQPSWrite                                float64
+	RateLimitBurstWrite                              int
+	setFlags                                         map[string]bool
+	parsed                                           bool
 }
 
 type optionsKey struct{}
@@ -123,6 +124,9 @@ Example in a JSON format:
 		int(cache.UnavailableOfferingsTTL.Seconds()),
 		"How long, in seconds, an offering observed to be out of host capacity is treated as "+
 			"unavailable before Karpenter retries it. Set to 0 to disable the unavailable-offerings cache")
+	fs.BoolVar(&o.EnableUnavailableOfferingsOnServiceLimitExceeded,
+		"enable-unavailable-offerings-on-service-limit-exceeded", false,
+		"Mark offerings unavailable when OCI service limits are exceeded")
 	fs.BoolVar(&o.DisableRateLimiter, "disable-rate-limiter", true,
 		"Disable the OCI client-side rate limiter")
 	fs.Float64Var(&o.RateLimitQPSRead, "rate-limit-qps-read", 0,

--- a/pkg/operator/options/options_test.go
+++ b/pkg/operator/options/options_test.go
@@ -249,6 +249,7 @@ var _ = Describe("Test Operator Options", func() {
 			"--instance-launch-timeout-failover", // "true"
 			"--unavailable-offerings-ttl-seconds",
 			"90",
+			"--enable-unavailable-offerings-on-service-limit-exceeded",
 			"--disable-rate-limiter",
 			"--rate-limit-qps-read",
 			"21",
@@ -293,6 +294,7 @@ var _ = Describe("Test Operator Options", func() {
 		Expect(o.InstanceOperationPollIntervalInSeconds).To(Equal(5))
 		Expect(o.InstanceLaunchTimeOutFailOver).To(BeTrue())
 		Expect(o.UnavailableOfferingsTTLSeconds).To(Equal(90))
+		Expect(o.EnableUnavailableOfferingsOnServiceLimitExceeded).To(BeTrue())
 		Expect(o.DisableRateLimiter).To(BeTrue())
 		Expect(o.RateLimitQPSRead).To(Equal(float64(21)))
 		Expect(o.RateLimitBurstRead).To(Equal(6))

--- a/pkg/providers/instance/error.go
+++ b/pkg/providers/instance/error.go
@@ -29,11 +29,12 @@ func IsNoCapacityError(err error) bool {
 }
 
 // IsSkippableLaunchError returns true for launch failures that should be skipped
-// in favor of trying another shape/offering: host-capacity exhaustion and
-// service-limit/compartment-quota exhaustion. When every candidate shape fails
-// with a skippable error, the caller surfaces an InsufficientCapacityError so
-// core Karpenter deletes and reschedules the NodeClaim onto another offering or
-// NodePool.
-func IsSkippableLaunchError(err error) bool {
-	return IsNoCapacityError(err) || oci.IsServiceLimitExceeded(err)
+// in favor of trying another shape/offering. Host-capacity exhaustion is always
+// skippable. Service-limit and compartment-quota exhaustion are skippable only
+// when unavailable-offering fallback for service limits is enabled.
+func IsSkippableLaunchError(err error, enableServiceLimitFallback bool) bool {
+	if IsNoCapacityError(err) {
+		return true
+	}
+	return enableServiceLimitFallback && oci.IsServiceLimitExceeded(err)
 }

--- a/pkg/providers/instance/error_test.go
+++ b/pkg/providers/instance/error_test.go
@@ -58,9 +58,10 @@ func quotaExceededError() error {
 
 func TestIsSkippableLaunchError(t *testing.T) {
 	testCases := []struct {
-		name string
-		err  error
-		want bool
+		name                       string
+		err                        error
+		enableServiceLimitFallback bool
+		want                       bool
 	}{
 		{
 			name: "nil error",
@@ -78,23 +79,40 @@ func TestIsSkippableLaunchError(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "service limit exceeded",
+			name: "service limit exceeded gate disabled",
 			err:  limitExceededError(),
-			want: true,
+			want: false,
 		},
 		{
-			name: "quota exceeded",
+			name:                       "service limit exceeded gate enabled",
+			err:                        limitExceededError(),
+			enableServiceLimitFallback: true,
+			want:                       true,
+		},
+		{
+			name: "quota exceeded gate disabled",
 			err: fakeServiceError{
 				httpStatus: http.StatusBadRequest,
 				code:       oci.QuotaExceeded,
 				message:    "compartment quota exceeded",
 			},
-			want: true,
+			want: false,
 		},
 		{
-			name: "wrapped service limit exceeded",
-			err:  pkgerrors.Wrap(limitExceededError(), "wrapped"),
-			want: true,
+			name: "quota exceeded gate enabled",
+			err: fakeServiceError{
+				httpStatus: http.StatusBadRequest,
+				code:       oci.QuotaExceeded,
+				message:    "compartment quota exceeded",
+			},
+			enableServiceLimitFallback: true,
+			want:                       true,
+		},
+		{
+			name:                       "wrapped service limit exceeded gate enabled",
+			err:                        pkgerrors.Wrap(limitExceededError(), "wrapped"),
+			enableServiceLimitFallback: true,
+			want:                       true,
 		},
 		{
 			name: "unrelated service error",
@@ -114,7 +132,7 @@ func TestIsSkippableLaunchError(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, IsSkippableLaunchError(tc.err))
+			assert.Equal(t, tc.want, IsSkippableLaunchError(tc.err, tc.enableServiceLimitFallback))
 		})
 	}
 }

--- a/pkg/providers/instance/provider.go
+++ b/pkg/providers/instance/provider.go
@@ -78,19 +78,20 @@ type Provider interface {
 }
 
 type DefaultProvider struct {
-	computeClient         oci.ComputeClient
-	workRequestClient     oci.WorkRequestClient
-	clusterCompartmentId  string
-	instanceMetaProvider  instancemeta.Provider
-	networkProvider       network.Provider
-	instanceCache         *cache.GetOrLoadCache[*InstanceInfo]
-	vnicAttachCache       *cache.GetOrLoadCache[[]*ocicore.VnicAttachment]
-	bootVolAttachCache    *cache.GetOrLoadCache[[]*ocicore.BootVolumeAttachment]
-	launchTimeoutVM       time.Duration
-	launchTimeoutBM       time.Duration
-	launchTimeOutFailOver bool
-	pollInterval          time.Duration
-	unavailableOfferings  *cache.UnavailableOfferings
+	computeClient                                    oci.ComputeClient
+	workRequestClient                                oci.WorkRequestClient
+	clusterCompartmentId                             string
+	instanceMetaProvider                             instancemeta.Provider
+	networkProvider                                  network.Provider
+	instanceCache                                    *cache.GetOrLoadCache[*InstanceInfo]
+	vnicAttachCache                                  *cache.GetOrLoadCache[[]*ocicore.VnicAttachment]
+	bootVolAttachCache                               *cache.GetOrLoadCache[[]*ocicore.BootVolumeAttachment]
+	launchTimeoutVM                                  time.Duration
+	launchTimeoutBM                                  time.Duration
+	launchTimeOutFailOver                            bool
+	pollInterval                                     time.Duration
+	unavailableOfferings                             *cache.UnavailableOfferings
+	enableUnavailableOfferingsOnServiceLimitExceeded bool
 }
 
 func NewProvider(ctx context.Context, computeClient oci.ComputeClient,
@@ -101,7 +102,8 @@ func NewProvider(ctx context.Context, computeClient oci.ComputeClient,
 	launchTimeoutVM, launchTimeoutBM time.Duration,
 	launchTimeOutFailOver bool,
 	pollInterval time.Duration,
-	unavailableOfferings *cache.UnavailableOfferings) (*DefaultProvider, error) {
+	unavailableOfferings *cache.UnavailableOfferings,
+	enableUnavailableOfferingsOnServiceLimitExceeded bool) (*DefaultProvider, error) {
 	p := &DefaultProvider{
 		computeClient:         computeClient,
 		workRequestClient:     workRequestClient,
@@ -116,6 +118,7 @@ func NewProvider(ctx context.Context, computeClient oci.ComputeClient,
 		launchTimeOutFailOver: launchTimeOutFailOver,
 		pollInterval:          pollInterval,
 		unavailableOfferings:  unavailableOfferings,
+		enableUnavailableOfferingsOnServiceLimitExceeded: enableUnavailableOfferingsOnServiceLimitExceeded,
 	}
 
 	return p, nil
@@ -156,15 +159,14 @@ func (p *DefaultProvider) LaunchInstance(ctx context.Context,
 		isPreemptible = true
 	}
 
-	// When a launch attempt fails because of a skippable capacity exhaustion (host-capacity
-	// shortage or service-limit/compartment-quota), record the
+	// When a launch attempt fails because of a skippable capacity exhaustion, record the
 	// (shape, ocpu/memory, AD/zone, capacity-type) offering as unavailable so it is excluded from
 	// offering availability until the cache entry expires, enabling spot->on-demand and
 	// cross-NodePool fallback. Scoping by the flexible-shape CPU/memory configuration keeps a
 	// failure for one config from suppressing the shape's other configs.
 	if p.unavailableOfferings != nil {
 		defer func() {
-			if !IsSkippableLaunchError(err) {
+			if !IsSkippableLaunchError(err, p.enableUnavailableOfferingsOnServiceLimitExceeded) {
 				return
 			}
 

--- a/pkg/providers/instance/provider_test.go
+++ b/pkg/providers/instance/provider_test.go
@@ -1209,11 +1209,13 @@ func TestProvider_LaunchInstance_MarksUnavailableOnSkippableError(t *testing.T) 
 	memory := lo.ToPtr(float32(16))
 
 	testCases := []struct {
-		name string
-		err  error
+		name             string
+		err              error
+		enableCacheEntry bool
 	}{
-		{name: "out of host capacity", err: outOfHostCapacityError()},
-		{name: "service limit exceeded", err: limitExceededError()},
+		{name: "out of host capacity", err: outOfHostCapacityError(), enableCacheEntry: true},
+		{name: "service limit exceeded", err: limitExceededError(), enableCacheEntry: false},
+		{name: "quota exceeded", err: quotaExceededError(), enableCacheEntry: false},
 	}
 
 	for _, tc := range testCases {
@@ -1240,10 +1242,9 @@ func TestProvider_LaunchInstance_MarksUnavailableOnSkippableError(t *testing.T) 
 				&instancetype.OciInstanceType{Shape: shape, SupportShapeConfig: true, Ocpu: ocpu, MemoryInGbs: memory},
 				imgRes, netRes, nil, pp)
 			require.Error(t, err)
-			// Host-capacity exhaustion and tenancy-scoped LimitExceeded apply regardless of
-			// compartment, so they are recorded under the tenancy-wide (empty compartment) scope.
-			assert.True(t, unavailable.IsUnavailable(shape, ocpu, memory, zone, corev1.CapacityTypeOnDemand, ""),
-				"expected the (shape, ocpu/memory, zone, capacity-type) offering to be marked unavailable")
+			assert.Equal(t, tc.enableCacheEntry,
+				unavailable.IsUnavailable(shape, ocpu, memory, zone, corev1.CapacityTypeOnDemand, ""),
+				"unexpected unavailable-offering cache entry")
 
 			// A different CPU/memory configuration of the same shape/zone/capacity-type must remain
 			// available, since only the failed config was observed to be out of capacity.
@@ -1252,6 +1253,42 @@ func TestProvider_LaunchInstance_MarksUnavailableOnSkippableError(t *testing.T) 
 				"a different flex config must not be suppressed by the failed config")
 		})
 	}
+}
+
+func TestProvider_LaunchInstance_MarksServiceLimitExceededWhenEnabled(t *testing.T) {
+	baseClaim := minimalNodeClaim()
+	baseNodeClass := minimalNodeClass()
+	imgRes := minimalImageResolve()
+	netRes := minimalNetworkResolve()
+	pp := minimalPlacement()
+	pp.Fd = nil
+
+	shape := testShapeE4Flex
+	zone := utils.AdToZoneLabelValue(pp.Ad)
+	ocpu := lo.ToPtr(float32(2))
+	memory := lo.ToPtr(float32(16))
+	unavailable := cache.NewUnavailableOfferings(cache.UnavailableOfferingsTTL)
+	p := &DefaultProvider{
+		computeClient:        &fakes.FakeCompute{LaunchErr: limitExceededError()},
+		clusterCompartmentId: "ocid1.compartment.oc1..parent",
+		instanceCache:        cache.NewDefaultGetOrLoadCache[*InstanceInfo](),
+		vnicAttachCache:      cache.NewDefaultGetOrLoadCache[[]*ocicore.VnicAttachment](),
+		bootVolAttachCache:   cache.NewDefaultGetOrLoadCache[[]*ocicore.BootVolumeAttachment](),
+		launchTimeoutVM:      10 * time.Minute,
+		launchTimeoutBM:      20 * time.Minute,
+		pollInterval:         time.Second,
+		unavailableOfferings: unavailable,
+		enableUnavailableOfferingsOnServiceLimitExceeded: true,
+	}
+	imdsp, err := instancemeta.NewProvider(context.TODO(), "10.0.0.1", []byte("CA"), ipV4SingleStack)
+	require.NoError(t, err)
+	p.instanceMetaProvider = imdsp
+
+	_, err = p.LaunchInstance(context.TODO(), baseClaim, baseNodeClass,
+		&instancetype.OciInstanceType{Shape: shape, SupportShapeConfig: true, Ocpu: ocpu, MemoryInGbs: memory},
+		imgRes, netRes, nil, pp)
+	require.Error(t, err)
+	assert.True(t, unavailable.IsUnavailable(shape, ocpu, memory, zone, corev1.CapacityTypeOnDemand, ""))
 }
 
 func TestProvider_LaunchInstance_MarksQuotaExceededScopedToCompartment(t *testing.T) {
@@ -1290,6 +1327,7 @@ func TestProvider_LaunchInstance_MarksQuotaExceededScopedToCompartment(t *testin
 		launchTimeoutBM:      20 * time.Minute,
 		pollInterval:         time.Second,
 		unavailableOfferings: unavailable,
+		enableUnavailableOfferingsOnServiceLimitExceeded: true,
 	}
 	imdsp, err := instancemeta.NewProvider(context.TODO(), "10.0.0.1", []byte("CA"), ipV4SingleStack)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Adds a Helm-controlled opt-in for caching unavailable offerings when OCI returns `LimitExceeded` service-limit errors.

By default, `LimitExceeded` errors no longer mark a shape/configuration as unavailable. This avoids masking otherwise valid capacity due to tenancy-wide service-limit conditions. Host-capacity and compartment-scoped quota failures retain their existing unavailable-offering behavior.

## Changes

- Adds `settings.enableUnavailableOfferingsOnServiceLimitExceeded` to the Helm chart, defaulting to `false`.
- Passes the setting through the controller options into the instance provider.
- Caches `LimitExceeded` failures only when the setting is explicitly enabled.
- Adds unit coverage for default-disabled and enabled behavior.
- Updates Helm chart reference documentation.

Fixes #51