### PR TITLE
fix: handle work request service limits

### DIFF
--- a/pkg/providers/instance/provider.go
+++ b/pkg/providers/instance/provider.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -91,6 +92,42 @@ type DefaultProvider struct {
 	launchTimeOutFailOver bool
 	pollInterval          time.Duration
 	unavailableOfferings  *cache.UnavailableOfferings
+}
+
+type workRequestServiceError struct {
+	code    string
+	message string
+}
+
+func (e workRequestServiceError) Error() string {
+	return e.message
+}
+
+func (e workRequestServiceError) GetHTTPStatusCode() int {
+	return http.StatusBadRequest
+}
+
+func (e workRequestServiceError) GetMessage() string {
+	return e.message
+}
+
+func (e workRequestServiceError) GetCode() string {
+	return e.code
+}
+
+func (e workRequestServiceError) GetOpcRequestID() string {
+	return ""
+}
+
+func newWorkRequestServiceError(item ociwr.WorkRequestError) error {
+	message := lo.FromPtr(item.Message)
+	if message == "" {
+		message = "work-request failed"
+	}
+	return workRequestServiceError{
+		code:    lo.FromPtr(item.Code),
+		message: message,
+	}
 }
 
 func NewProvider(ctx context.Context, computeClient oci.ComputeClient,
@@ -307,8 +344,8 @@ func (p *DefaultProvider) LaunchInstance(ctx context.Context,
 				if listWrErr != nil {
 					return nil, errors.New("work-request failed")
 				}
-				if len(errResp.Items) > 0 && errResp.Items[0].Message != nil {
-					err = errors.New(*errResp.Items[0].Message)
+				if len(errResp.Items) > 0 {
+					err = newWorkRequestServiceError(errResp.Items[0])
 					if oci.IsOutOfHostCapacity(err) {
 						return nil, NoCapacityError{}
 					}

--- a/pkg/providers/instance/provider_test.go
+++ b/pkg/providers/instance/provider_test.go
@@ -1644,6 +1644,77 @@ func TestProvider_LaunchInstance_WorkRequestOutOfHostCapacity(t *testing.T) {
 	assert.Equal(t, 1, fwr.ListCount.Get())
 }
 
+func TestProvider_LaunchInstance_WorkRequestServiceLimitExceeded(t *testing.T) {
+	fc := &fakes.FakeCompute{}
+	fwr := &fakes.FakeWorkRequest{}
+
+	fc.OnLaunch = func(ctx context.Context, r ocicore.LaunchInstanceRequest) (ocicore.LaunchInstanceResponse, error) {
+		return ocicore.LaunchInstanceResponse{
+			Instance: ocicore.Instance{Id: lo.ToPtr("ocid1.instance.oc1..new")},
+			Etag:     lo.ToPtr("etag-new"),
+			RawResponse: &http.Response{
+				StatusCode: 200,
+				Header: http.Header{
+					"Opc-Work-Request-Id": []string{"wr-launch-123"},
+				},
+			},
+		}, nil
+	}
+
+	fwr.GetResp = ociwr.GetWorkRequestResponse{
+		WorkRequest: ociwr.WorkRequest{
+			Status:       ociwr.WorkRequestStatusFailed,
+			TimeFinished: &common.SDKTime{Time: time.Now()},
+			TimeStarted:  &common.SDKTime{Time: time.Now()},
+		},
+	}
+	fwr.ListErrorsResp = ociwr.ListWorkRequestErrorsResponse{
+		Items: []ociwr.WorkRequestError{{
+			Code:      lo.ToPtr("LimitExceeded"),
+			Message:   lo.ToPtr("The following service limits were exceeded: standard-e4-core-count"),
+			Timestamp: &common.SDKTime{Time: time.Now()},
+		}},
+	}
+
+	imdsp, err := instancemeta.NewProvider(context.TODO(), "10.0.0.1", []byte("CA"), ipV4SingleStack)
+	require.NoError(t, err)
+	unavailable := cache.NewUnavailableOfferings(cache.UnavailableOfferingsTTL)
+	p := &DefaultProvider{
+		computeClient:        fc,
+		workRequestClient:    fwr,
+		instanceMetaProvider: imdsp,
+		clusterCompartmentId: "ocid1.compartment.oc1..parent",
+		launchTimeoutVM:      10 * time.Minute,
+		launchTimeoutBM:      20 * time.Minute,
+		pollInterval:         time.Millisecond,
+		unavailableOfferings: unavailable,
+	}
+
+	ocpu := lo.ToPtr(float32(2))
+	memory := lo.ToPtr(float32(16))
+	it := &instancetype.OciInstanceType{
+		InstanceType: cloudprovider.InstanceType{
+			Name:      testShapeE4Flex,
+			Offerings: cloudprovider.Offerings{makeOfferingWithCapType(corev1.CapacityTypeOnDemand)},
+		},
+		Shape:              testShapeE4Flex,
+		SupportShapeConfig: true,
+		Ocpu:               ocpu,
+		MemoryInGbs:        memory,
+	}
+	pp := minimalPlacement()
+	pp.Fd = nil
+
+	_, err = p.LaunchInstance(context.TODO(), minimalNodeClaim(), minimalNodeClass(), it, minimalImageResolve(),
+		minimalNetworkResolve(), nil, pp)
+	require.Error(t, err)
+	assert.True(t, IsSkippableLaunchError(err))
+	assert.Contains(t, err.Error(), "service limits were exceeded")
+	assert.True(t, unavailable.IsUnavailable(testShapeE4Flex, ocpu, memory, utils.AdToZoneLabelValue(pp.Ad),
+		corev1.CapacityTypeOnDemand, ""))
+	assert.Equal(t, 1, fwr.ListCount.Get())
+}
+
 func TestProvider_LaunchInstance_Timeout(t *testing.T) {
 	fc := &fakes.FakeCompute{}
 	fwr := &fakes.FakeWorkRequest{}


### PR DESCRIPTION
## Summary
- preserve OCI work-request error codes when a launch work request fails
- let async `LimitExceeded` and `QuotaExceeded` failures use the existing skippable launch-error path
- add coverage for a failed launch work request with `LimitExceeded`

Fixes #51

## Root Cause
The synchronous `LaunchInstance` error path already classified OCI `LimitExceeded` errors as skippable, which lets the cloud provider advance to the next candidate instance type. The async work-request failure path discarded the machine-readable work-request `Code` and returned only `errors.New(message)`, so a `LimitExceeded` work-request failure was treated as a generic launch failure instead of insufficient capacity.

## Fix
Convert failed work-request items into an error that preserves the OCI service-error interface. This keeps the existing `IsSkippableLaunchError` and unavailable-offerings cache behavior working for async service-limit failures without changing the launch loop.

## Testing
- `env GOCACHE=/tmp/karpenter-go-cache go test ./pkg/providers/instance`
- `env GOCACHE=/tmp/karpenter-go-cache go test ./pkg/cloudprovider ./pkg/providers/instance`
- `env GOCACHE=/tmp/karpenter-go-cache GOLANGCI_LINT_CACHE=/tmp/karpenter-golangci-cache /tmp/karpenter-tools/golangci-lint run ./pkg/providers/instance`
