### PR TITLE
refactor: use non-expiring instance-scoped drift caches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,10 +19,10 @@ jobs:
     steps:
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
         id: go

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       IMAGE_REGISTRY: ghcr.io/oracle
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Derive release versions
         id: versions
@@ -54,7 +54,7 @@ jobs:
             --destination dist
 
       - name: Checkout gh-pages
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           path: gh-pages

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 
 # --- Builder Stage ---
 ARG BUILDER_IMAGE=golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2
-ARG BASE_IMAGE=oraclelinux:8-slim@sha256:a3a035882eb662745ba8db2be2a7537932807cb4c459b71ad2a3c3dd27e8f5c0
+ARG BASE_IMAGE=oraclelinux:8-slim@sha256:3557a80ab147f6e3da8853a77563b14e705fd31d1b1a8674dfa1a40b875d37e7
 FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE AS builder
 
 ARG TARGETOS=linux

--- a/docs/guide/ocinodeclass.md
+++ b/docs/guide/ocinodeclass.md
@@ -52,6 +52,7 @@ KPO combines the `OCINodeClass` with a Karpenter `NodePool` during provisioning.
 - `spec.capacityReservationConfigs`, `spec.clusterPlacementGroupConfigs`, and `spec.computeClusterConfig` are mutually exclusive. 
 - Resource selector fields such as `subnetFilter`, `networkSecurityGroupFilter`, and reservation or placement-group filters must resolve to exactly one OCI resource.
 - `spec.preBootstrapInitScript` and `spec.postBootstrapInitScript` must contain base64-encoded scripts.
+- KPO does not guarantee drift detection for changes made directly in OCI outside Karpenter.
 
 ## Status and troubleshooting
 

--- a/docs/reference/helm-chart.md
+++ b/docs/reference/helm-chart.md
@@ -74,6 +74,7 @@ A Helm chart for Karpenter provider OCI
 | settings.batchIdleDuration | string | `"1s"` | The maximum amount of time with no new ending pods that if exceeded ends the current batching window. If pods arrive faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods will be batched separately. |
 | settings.batchMaxDuration | string | `"10s"` | The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes. |
 | settings.clusterCompartmentId | string | `""` | [required] Cluster compartment OCID. |
+| settings.enableUnavailableOfferingsOnServiceLimitExceeded | bool | `false` | When true, OCI LimitExceeded and QuotaExceeded failures mark the offering unavailable. Disabled by default. |
 | settings.featureGates | object | `{"nodeOverlay":false,"nodeRepair":false,"spotToSpotConsolidation":false,"staticCapacity":false}` | Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features |
 | settings.featureGates.nodeOverlay | bool | `false` | nodeOverlay is ALPHA and is disabled by default. Setting this to true will enable nodeOverlay. |
 | settings.featureGates.nodeRepair | bool | `false` | nodeRepair is ALPHA and is disabled by default. Setting this to true will enable node repair. |
@@ -89,7 +90,6 @@ A Helm chart for Karpenter provider OCI
 | settings.rateLimiter.qpsRead | float | `0` | Read QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
 | settings.rateLimiter.qpsWrite | float | `0` | Write QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
 | settings.unavailableOfferingsTTLSeconds | int | `180` | How long, in seconds, an offering observed to be out of host capacity is treated as unavailable before Karpenter retries it. Lower values retry exhausted offerings sooner; higher values reduce repeated launch attempts (and OCI throttling) against capacity that is unlikely to recover quickly. Set to 0 to disable the unavailable-offerings cache entirely, in which case offerings are never marked unavailable and Karpenter does not route around capacity-exhausted offerings. |
-| settings.enableUnavailableOfferingsOnServiceLimitExceeded | bool | `false` | When true, OCI LimitExceeded and QuotaExceeded failures mark the offering unavailable. Disabled by default. |
 | settings.vcnCompartmentId | string | `""` | [required] Cluster's VCN compartment OCID. |
 | strategy | object | `{"rollingUpdate":{"maxUnavailable":1}}` | Strategy for updating the pod. |
 | terminationGracePeriodSeconds | string | `nil` | Override the default termination grace period for the pod. |
@@ -97,3 +97,4 @@ A Helm chart for Karpenter provider OCI
 | topologySpreadConstraints | list | `[{"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"DoNotSchedule"}]` | Topology spread constraints to increase the controller resilience by distributing pods across the cluster zones. If an explicit label selector is not provided one will be created from the pod selector labels. |
 | volumeMounts | list | `[]` | Additional volume mounts on the controller container. |
 | volumes | list | `[]` | Additional volumes on the controller Deployment. |
+

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -9,7 +9,6 @@ package cache
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -51,6 +50,14 @@ func NewDefaultGetOrLoadCache[T any]() *GetOrLoadCache[T] {
 	}
 }
 
+// NewNonExpiringGetOrLoadCache creates a cache whose entries are retained until
+// they are explicitly replaced or evicted.
+func NewNonExpiringGetOrLoadCache[T any]() *GetOrLoadCache[T] {
+	return &GetOrLoadCache[T]{
+		cache: cache.New(cache.NoExpiration, cache.NoExpiration),
+	}
+}
+
 func (c *GetOrLoadCache[T]) GetOrLoad(ctx context.Context, key string,
 	loader LoaderFunc[T]) (T, error) {
 	t, found := c.getFromCache(ctx, key)
@@ -58,25 +65,62 @@ func (c *GetOrLoadCache[T]) GetOrLoad(ctx context.Context, key string,
 		return t, nil
 	}
 
-	// Lock for this key to avoid duplicate loads
+	// Lock for this key to avoid duplicate loads.
 	muIface, _ := c.locks.LoadOrStore(key, &sync.Mutex{})
 	mu := muIface.(*sync.Mutex)
 	mu.Lock()
-	defer mu.Unlock()
 	defer c.locks.Delete(key)
+	defer mu.Unlock()
 
-	// Double-check cache after acquiring lock (with safe assertion)
+	// Double-check after acquiring the lock.
 	t, found = c.getFromCache(ctx, key)
 	if found {
 		return t, nil
 	}
 
-	// Load, store, return
 	return c.load(ctx, key, loader)
 }
 
-func (c *GetOrLoadCache[T]) Evict(ctx context.Context, key string) {
+// Evict removes the current entry. An in-flight load may repopulate it after eviction.
+func (c *GetOrLoadCache[T]) Evict(key string) {
 	c.cache.Delete(key)
+}
+
+// Set exposes the underlying typed cache write operation.
+func (c *GetOrLoadCache[T]) Set(key string, value T) {
+	c.cache.Set(key, value, cache.DefaultExpiration)
+}
+
+// Refresh always invokes the loader and replaces the cached value only after
+// a successful load.
+func (c *GetOrLoadCache[T]) Refresh(ctx context.Context, key string,
+	loader LoaderFunc[T]) (T, error) {
+	return c.load(ctx, key, loader)
+}
+
+// OnEvicted registers a typed callback that runs when an existing entry is
+// explicitly evicted or expires. Overwriting an entry does not invoke it.
+func (c *GetOrLoadCache[T]) OnEvicted(callback func(key string, value T)) {
+	if callback == nil {
+		c.cache.OnEvicted(nil)
+		return
+	}
+	c.cache.OnEvicted(func(key string, value interface{}) {
+		typed, ok := value.(T)
+		if ok {
+			callback(key, typed)
+		}
+	})
+}
+
+// EvictMatching removes all current entries whose keys match the predicate. An in-flight load may
+// repopulate an entry after eviction.
+func (c *GetOrLoadCache[T]) EvictMatching(match func(key string) bool) {
+	for key := range c.cache.Items() {
+		if match(key) {
+			c.cache.Delete(key)
+		}
+	}
 }
 
 func (c *GetOrLoadCache[T]) getFromCache(ctx context.Context, key string) (T, bool) {
@@ -105,8 +149,4 @@ func (c *GetOrLoadCache[T]) load(ctx context.Context, key string, loader LoaderF
 
 	var zero T
 	return zero, err
-}
-
-func MakeCompositeKey(values ...string) string {
-	return strings.Join(values, "|")
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -18,18 +18,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewGetOrLoadCache(t *testing.T) {
-	defaultExp := 5 * time.Minute
-	cleanup := 10 * time.Minute
-	c := NewGetOrLoadCache[string](defaultExp, cleanup)
-	assert.NotNil(t, c)
-	assert.NotNil(t, c.cache)
+func TestNewNonExpiringGetOrLoadCache(t *testing.T) {
+	c := NewNonExpiringGetOrLoadCache[string]()
+	c.Set("key", "first")
+	c.Set("key", "second")
+
+	item, found := c.cache.Items()["key"]
+	assert.True(t, found)
+	assert.Equal(t, "second", item.Object)
+	assert.Equal(t, int64(0), item.Expiration)
 }
 
-func TestNewDefaultGetOrLoadCache(t *testing.T) {
-	c := NewDefaultGetOrLoadCache[string]()
-	assert.NotNil(t, c)
-	assert.NotNil(t, c.cache)
+func TestEvictMatching(t *testing.T) {
+	c := NewNonExpiringGetOrLoadCache[string]()
+	c.Set("instance-1", "one")
+	c.Set("instance-2", "two")
+
+	c.EvictMatching(func(key string) bool {
+		return key == "instance-2"
+	})
+
+	_, found := c.cache.Get("instance-1")
+	assert.True(t, found)
+	_, found = c.cache.Get("instance-2")
+	assert.False(t, found)
 }
 
 func TestGetOrLoad_HappyPath(t *testing.T) {
@@ -133,6 +145,31 @@ func TestGetOrLoad_Concurrent(t *testing.T) {
 	}
 }
 
+func TestRefresh(t *testing.T) {
+	c := NewNonExpiringGetOrLoadCache[string]()
+	ctx := context.Background()
+	c.Set("key", "old")
+
+	value, err := c.Refresh(ctx, "key", func(context.Context, string) (string, error) {
+		return "new", nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "new", value)
+
+	expectedErr := errors.New("refresh failed")
+	_, err = c.Refresh(ctx, "key", func(context.Context, string) (string, error) {
+		return "", expectedErr
+	})
+	assert.ErrorIs(t, err, expectedErr)
+
+	value, err = c.GetOrLoad(ctx, "key", func(context.Context, string) (string, error) {
+		t.Fatal("preserved value should be served from cache")
+		return "", nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "new", value)
+}
+
 func TestEvict(t *testing.T) {
 	c := NewDefaultGetOrLoadCache[string]()
 	ctx := context.Background()
@@ -151,7 +188,7 @@ func TestEvict(t *testing.T) {
 	assert.Equal(t, expected, val)
 
 	// Evict
-	c.Evict(ctx, key)
+	c.Evict(key)
 
 	// Next call should miss cache
 	loaderCalled := false
@@ -164,22 +201,23 @@ func TestEvict(t *testing.T) {
 	assert.Equal(t, "new-value", val2)
 }
 
-func TestMakeCompositeKey(t *testing.T) {
-	tests := []struct {
-		name     string
-		values   []string
-		expected string
-	}{
-		{"empty", []string{}, ""},
-		{"single", []string{"a"}, "a"},
-		{"multiple", []string{"a", "b", "c"}, "a|b|c"},
-		{"with empty", []string{"a", "", "c"}, "a||c"},
-	}
+func TestOnEvicted(t *testing.T) {
+	c := NewNonExpiringGetOrLoadCache[string]()
+	var evictedKeys []string
+	var evictedValues []string
+	c.OnEvicted(func(key, value string) {
+		evictedKeys = append(evictedKeys, key)
+		evictedValues = append(evictedValues, value)
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := MakeCompositeKey(tt.values...)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+	c.Set("key", "first")
+	c.Set("key", "second")
+	assert.Empty(t, evictedKeys, "overwriting an entry must not invoke OnEvicted")
+
+	c.Evict("missing")
+	assert.Empty(t, evictedKeys, "evicting a missing entry must not invoke OnEvicted")
+
+	c.Evict("key")
+	assert.Equal(t, []string{"key"}, evictedKeys)
+	assert.Equal(t, []string{"second"}, evictedValues)
 }

--- a/pkg/cloudprovider/cloud_provider.go
+++ b/pkg/cloudprovider/cloud_provider.go
@@ -500,7 +500,6 @@ func (c *CloudProvider) List(ctx context.Context) ([]*corev1.NodeClaim, error) {
 	}))
 
 	var nodeClaims []*corev1.NodeClaim
-	var ins []*ocicore.Instance
 
 	nodePoolNameSet := sets.New(lo.Map(nodePoolList.Items, func(item corev1.NodePool, _ int) string {
 		return item.Name
@@ -510,28 +509,26 @@ func (c *CloudProvider) List(ctx context.Context) ([]*corev1.NodeClaim, error) {
 		return item.Name, string(item.UID)
 	})
 
-	for _, compartmentId := range nodeCompartments {
-		ins, err = c.instanceProvider.ListInstances(ctx, compartmentId)
-		if err != nil {
-			return nil, err
+	ins, err := c.instanceProvider.ListInstances(ctx, nodeCompartments)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, i := range ins {
+		nodePoolName, ok := instance.GetNodePoolNameFromInstance(i)
+		if !ok || !isInstanceOwnedByNodePool(i, nodePoolUIDByName[nodePoolName]) {
+			continue
 		}
 
-		for _, i := range ins {
-			nodePoolName, ok := instance.GetNodePoolNameFromInstance(i)
-			if !ok || !isInstanceOwnedByNodePool(i, nodePoolUIDByName[nodePoolName]) {
-				continue
-			}
+		nodeClaim, inerr := c.createNodeClaimFromInstance(ctx, i)
+		if inerr != nil {
+			return nil, inerr
+		}
 
-			nodeClaim, inerr := c.createNodeClaimFromInstance(ctx, i)
-			if inerr != nil {
-				return nil, inerr
-			}
-
-			// filter out instances that are unknown.
-			if nodePoolNameSet.Has(nodeClaim.Labels[corev1.NodePoolLabelKey]) {
-				c.placementProvider.InstanceFound(nodeClaim.Labels[corev1.NodePoolLabelKey], i)
-				nodeClaims = append(nodeClaims, nodeClaim)
-			}
+		// filter out instances that are unknown.
+		if nodePoolNameSet.Has(nodeClaim.Labels[corev1.NodePoolLabelKey]) {
+			c.placementProvider.InstanceFound(nodeClaim.Labels[corev1.NodePoolLabelKey], i)
+			nodeClaims = append(nodeClaims, nodeClaim)
 		}
 	}
 
@@ -718,7 +715,6 @@ func (c *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *corev1.NodeCla
 
 	// ---- 1. INSTANCE DRIFT (CACHED, then REAL) ----
 	instanceCached, err := c.instanceProvider.GetInstanceCached(ctx, nodeClaim.Status.ProviderID)
-	// TODO: handle not found
 	if err != nil {
 		return "", fmt.Errorf("drifted status unknown: %v", err)
 	}
@@ -748,11 +744,7 @@ func (c *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *corev1.NodeCla
 	if err != nil {
 		return "", err
 	}
-
-	var skipSecondaryVnicsCheck bool
-	if !nodeClaim.StatusConditions().Get(corev1.ConditionTypeInitialized).IsTrue() {
-		skipSecondaryVnicsCheck = true
-	}
+	skipSecondaryVnicsCheck := !nodeClaim.StatusConditions().Get(corev1.ConditionTypeInitialized).IsTrue()
 
 	reason, err = IsInstanceNetworkDrifted(ctx, desiredInstanceState, vnicCached,
 		func(ctx context.Context, vnicOcid string) (*ocicore.Vnic, error) {

--- a/pkg/cloudprovider/cloud_provider_test.go
+++ b/pkg/cloudprovider/cloud_provider_test.go
@@ -61,6 +61,9 @@ const (
 	nodeClassClusterCompartmentID = "ocid1.compartment.oc1..cluster123"
 	sharedCompartmentID           = "ocid1.compartment.oc1..shared"
 	testImageID                   = "ocid1.image.oc1..test"
+	testShapeA                    = "shape-a"
+	testCompartmentA              = "ocid1.compartment.oc1..a"
+	testCompartmentB              = "ocid1.compartment.oc1..b"
 )
 
 var (
@@ -76,6 +79,7 @@ var _ = Describe("CloudProvider Integration Tests", func() {
 
 	BeforeEach(func() {
 		ipV4Family := []network.IpFamily{network.IPv4}
+		driftCaches := instance.NewDriftCaches()
 
 		ociTestNodeClass = fakes.CreateOciNodeClassWithMinimumReconcilableSetting(nodeClassClusterCompartmentID)
 		imageProvider := lo.Must(image.NewProvider(ctx, nil, fakes.NewFakeComputeClient(nodeClassClusterCompartmentID),
@@ -83,7 +87,7 @@ var _ = Describe("CloudProvider Integration Tests", func() {
 		kmsProvider := lo.Must(kms.NewProvider(ctx, nodeClassClusterCompartmentID, fakes.NewDummyConfigurationProvider()))
 		kmsProvider.SetKmsClient("https://testvalut-management.kms.us-ashburn-1.oraclecloud.com", fakes.NewFakeKmsClient())
 		networkProvider := lo.Must(network.NewProvider(ctx, nodeClassClusterCompartmentID,
-			false, ipV4Family, fakes.NewFakeVirtualNetworkClient()))
+			false, ipV4Family, fakes.NewFakeVirtualNetworkClient(), driftCaches.VnicCache()))
 		crProvider := capacityreservation.NewProvider(ctx,
 			fakes.NewFakeCapacityReservationClient(nodeClassClusterCompartmentID), nodeClassClusterCompartmentID)
 		computeClusterProvider := computecluster.NewProvider(ctx,
@@ -110,7 +114,8 @@ var _ = Describe("CloudProvider Integration Tests", func() {
 				},
 			},
 		})
-		bsProvider := lo.Must(blockstorage.NewProvider(ctx, &fakes.FakeBlockstorage{}))
+		bsProvider := lo.Must(blockstorage.NewProvider(ctx, &fakes.FakeBlockstorage{},
+			driftCaches.BootVolumeCache()))
 		ociNodeClassController = lo.Must(nodeclasses.NewController(ctx, k8sClient,
 			&fakes.FakeEventRecorder{},
 			imageProvider,
@@ -223,14 +228,14 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			nodePool := testNodePool(uniqueName("nodepool"), nodeClass.Name)
 			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
 				kubeClient:    newFakeKubeClient(nodeClass, nodePool),
-				instanceTypes: []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+				instanceTypes: []*instancetype.OciInstanceType{testInstanceType(testShapeA, 10)},
 				repairPolicies: []cloudprovider.RepairPolicy{
 					{ConditionType: corev1.NodeReady},
 				},
 			})
 
 			resolvedPool, err := cp.resolveNodePoolFromInstance(context.Background(),
-				testInstanceWithShape("shape-a", nodePool.Name))
+				testInstanceWithShape(testShapeA, nodePool.Name))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resolvedPool.Name).To(Equal(nodePool.Name))
 
@@ -244,7 +249,7 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			instanceTypes, err := cp.GetInstanceTypes(context.Background(), nodePool)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(instanceTypes).To(HaveLen(1))
-			Expect(instanceTypes[0].Name).To(Equal("shape-a"))
+			Expect(instanceTypes[0].Name).To(Equal(testShapeA))
 
 			Expect(cp.RepairPolicies()).To(HaveLen(1))
 			Expect(cp.Name()).To(Equal("oci"))
@@ -265,27 +270,27 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			nodePool = testNodePool(uniqueName("nodepool"), nodeClass.Name)
 			cp = newUnitTestCloudProvider(unitTestCloudProviderOptions{
 				kubeClient:    newFakeKubeClient(nodeClass, nodePool),
-				instanceTypes: []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+				instanceTypes: []*instancetype.OciInstanceType{testInstanceType(testShapeA, 10)},
 			})
 		})
 
 		It("should hydrate nodeclaims from active instances", func() {
 			cp.instanceProvider = &FakeInstanceProvider{
 				GetInstanceFn: func(context.Context, string) (*instance.InstanceInfo, error) {
-					return &instance.InstanceInfo{Instance: testInstanceWithShape("shape-a", nodePool.Name)}, nil
+					return &instance.InstanceInfo{Instance: testInstanceWithShape(testShapeA, nodePool.Name)}, nil
 				},
 			}
 
 			nodeClaim, err := cp.Get(context.Background(), "ocid1.instance.oc1..get")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nodeClaim.Labels[v1.NodePoolLabelKey]).To(Equal(nodePool.Name))
-			Expect(nodeClaim.Labels[corev1.LabelInstanceTypeStable]).To(Equal("shape-a"))
+			Expect(nodeClaim.Labels[corev1.LabelInstanceTypeStable]).To(Equal(testShapeA))
 		})
 
 		It("should treat terminated instances as not found", func() {
 			cp.instanceProvider = &FakeInstanceProvider{
 				GetInstanceFn: func(context.Context, string) (*instance.InstanceInfo, error) {
-					i := testInstanceWithShape("shape-a", nodePool.Name)
+					i := testInstanceWithShape(testShapeA, nodePool.Name)
 					i.LifecycleState = ocicore.InstanceLifecycleStateTerminated
 					return &instance.InstanceInfo{Instance: i}, nil
 				},
@@ -352,7 +357,7 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 		It("should forget terminated instances", func() {
 			cp.instanceProvider = &FakeInstanceProvider{
 				GetInstanceFn: func(context.Context, string) (*instance.InstanceInfo, error) {
-					i := testInstanceWithShape("shape-a", "pool-a")
+					i := testInstanceWithShape(testShapeA, "pool-a")
 					i.LifecycleState = ocicore.InstanceLifecycleStateTerminated
 					i.Id = lo.ToPtr(nodeClaim.Status.ProviderID)
 					return &instance.InstanceInfo{Instance: i}, nil
@@ -367,7 +372,7 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 		It("should surface delete not found as already deleted", func() {
 			cp.instanceProvider = &FakeInstanceProvider{
 				GetInstanceFn: func(context.Context, string) (*instance.InstanceInfo, error) {
-					i := testInstanceWithShape("shape-a", "pool-a")
+					i := testInstanceWithShape(testShapeA, "pool-a")
 					i.Id = lo.ToPtr(nodeClaim.Status.ProviderID)
 					return &instance.InstanceInfo{Instance: i}, nil
 				},
@@ -383,7 +388,7 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 		It("should release capacity reservations after a successful delete", func() {
 			cp.instanceProvider = &FakeInstanceProvider{
 				GetInstanceFn: func(context.Context, string) (*instance.InstanceInfo, error) {
-					i := testInstanceWithShape("shape-a", "pool-a")
+					i := testInstanceWithShape(testShapeA, "pool-a")
 					i.Id = lo.ToPtr(nodeClaim.Status.ProviderID)
 					i.CapacityReservationId = lo.ToPtr("ocid1.capacityreservation.oc1..abc")
 					return &instance.InstanceInfo{Instance: i}, nil
@@ -399,7 +404,7 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			deleteCalled := false
 			cp.instanceProvider = &FakeInstanceProvider{
 				GetInstanceFn: func(context.Context, string) (*instance.InstanceInfo, error) {
-					i := testInstanceWithShape("shape-a", "pool-a")
+					i := testInstanceWithShape(testShapeA, "pool-a")
 					i.Id = lo.ToPtr(nodeClaim.Status.ProviderID)
 					i.FreeformTags[instance.NodePoolUIDOciFreeFormTagKey] = "other-nodepool-uid"
 					return &instance.InstanceInfo{Instance: i}, nil
@@ -417,24 +422,31 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 
 	Context("List", func() {
 		It("should list instances only for in-use nodeclasses and filter unknown nodepools", func() {
-			usedNodeClass := testReadyNodeClass(uniqueName("used"))
-			compartmentA := "ocid1.compartment.oc1..a"
-			usedNodeClass.Spec.NodeCompartmentId = &compartmentA
+			compartmentA := testCompartmentA
+			usedNodeClassA := testReadyNodeClass(uniqueName("used-a"))
+			usedNodeClassA.Spec.NodeCompartmentId = &compartmentA
+			compartmentB := testCompartmentB
+			usedNodeClassB := testReadyNodeClass(uniqueName("used-b"))
+			usedNodeClassB.Spec.NodeCompartmentId = &compartmentB
 			unusedNodeClass := testReadyNodeClass(uniqueName("unused"))
-			compartmentB := "ocid1.compartment.oc1..b"
-			unusedNodeClass.Spec.NodeCompartmentId = &compartmentB
+			unusedCompartment := sharedCompartmentID
+			unusedNodeClass.Spec.NodeCompartmentId = &unusedCompartment
 
-			nodePool := testNodePool(uniqueName("nodepool"), usedNodeClass.Name)
+			nodePoolA := testNodePool(uniqueName("nodepool-a"), usedNodeClassA.Name)
+			nodePoolB := testNodePool(uniqueName("nodepool-b"), usedNodeClassB.Name)
 			var listedCompartments []string
+			listCalls := 0
 			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
-				kubeClient:    newFakeKubeClient(usedNodeClass, unusedNodeClass, nodePool),
-				instanceTypes: []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+				kubeClient: newFakeKubeClient(
+					usedNodeClassA, usedNodeClassB, unusedNodeClass, nodePoolA, nodePoolB),
+				instanceTypes: []*instancetype.OciInstanceType{testInstanceType(testShapeA, 10)},
 				instanceProvider: &FakeInstanceProvider{
-					ListInstancesFn: func(_ context.Context, compartmentID string) ([]*ocicore.Instance, error) {
-						listedCompartments = append(listedCompartments, compartmentID)
+					ListInstancesFn: func(_ context.Context, compartmentIDs []string) ([]*ocicore.Instance, error) {
+						listCalls++
+						listedCompartments = append(listedCompartments, compartmentIDs...)
 						return []*ocicore.Instance{
-							testInstanceWithShape("shape-a", nodePool.Name),
-							testInstanceWithShape("shape-a", "unknown-pool"),
+							testInstanceWithShape(testShapeA, nodePoolA.Name),
+							testInstanceWithShape(testShapeA, "unknown-pool"),
 						}, nil
 					},
 				},
@@ -442,9 +454,11 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 
 			nodeClaims, err := cp.List(context.Background())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(listedCompartments).To(Equal([]string{compartmentA}))
+			Expect(listCalls).To(Equal(1))
+			Expect(listedCompartments).To(ConsistOf(compartmentA, compartmentB))
+			Expect(listedCompartments).ToNot(ContainElement(unusedCompartment))
 			Expect(nodeClaims).To(HaveLen(1))
-			Expect(nodeClaims[0].Labels[v1.NodePoolLabelKey]).To(Equal(nodePool.Name))
+			Expect(nodeClaims[0].Labels[v1.NodePoolLabelKey]).To(Equal(nodePoolA.Name))
 		})
 
 		It("should include instances when nodepool name and UID match", func() {
@@ -452,14 +466,14 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			compartment := sharedCompartmentID
 			nodeClass.Spec.NodeCompartmentId = &compartment
 			nodePool := testNodePoolWithUID(uniqueName("nodepool"), nodeClass.Name)
-			localInstance := testInstanceWithShape("shape-a", nodePool.Name)
+			localInstance := testInstanceWithShape(testShapeA, nodePool.Name)
 			localInstance.FreeformTags[instance.NodePoolUIDOciFreeFormTagKey] = string(nodePool.UID)
 
 			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
 				kubeClient:    newFakeKubeClient(nodeClass, nodePool),
-				instanceTypes: []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+				instanceTypes: []*instancetype.OciInstanceType{testInstanceType(testShapeA, 10)},
 				instanceProvider: &FakeInstanceProvider{
-					ListInstancesFn: func(_ context.Context, _ string) ([]*ocicore.Instance, error) {
+					ListInstancesFn: func(_ context.Context, _ []string) ([]*ocicore.Instance, error) {
 						return []*ocicore.Instance{localInstance}, nil
 					},
 				},
@@ -476,14 +490,14 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			compartment := sharedCompartmentID
 			nodeClass.Spec.NodeCompartmentId = &compartment
 			nodePool := testNodePoolWithUID(uniqueName("nodepool"), nodeClass.Name)
-			foreignInstance := testInstanceWithShape("shape-a", nodePool.Name)
+			foreignInstance := testInstanceWithShape(testShapeA, nodePool.Name)
 			foreignInstance.FreeformTags[instance.NodePoolUIDOciFreeFormTagKey] = "other-nodepool-uid"
 
 			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
 				kubeClient:    newFakeKubeClient(nodeClass, nodePool),
-				instanceTypes: []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+				instanceTypes: []*instancetype.OciInstanceType{testInstanceType(testShapeA, 10)},
 				instanceProvider: &FakeInstanceProvider{
-					ListInstancesFn: func(_ context.Context, _ string) ([]*ocicore.Instance, error) {
+					ListInstancesFn: func(_ context.Context, _ []string) ([]*ocicore.Instance, error) {
 						return []*ocicore.Instance{foreignInstance}, nil
 					},
 				},
@@ -500,19 +514,19 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			nodeClass.Spec.NodeCompartmentId = &compartment
 			nodePool := testNodePool("pool-a", nodeClass.Name)
 
-			ownedLegacy := testInstanceWithShape("shape-a", nodePool.Name)
+			ownedLegacy := testInstanceWithShape(testShapeA, nodePool.Name)
 			ownedLegacy.Id = lo.ToPtr("ocid1.instance.oc1..legacy-owned")
 			delete(ownedLegacy.FreeformTags, instance.NodePoolUIDOciFreeFormTagKey)
 
-			unownedLegacy := testInstanceWithShape("shape-a", nodePool.Name)
+			unownedLegacy := testInstanceWithShape(testShapeA, nodePool.Name)
 			unownedLegacy.Id = lo.ToPtr("ocid1.instance.oc1..legacy-unowned")
 			delete(unownedLegacy.FreeformTags, instance.NodePoolUIDOciFreeFormTagKey)
 
 			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
 				kubeClient:    newFakeKubeClient(nodeClass, nodePool),
-				instanceTypes: []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+				instanceTypes: []*instancetype.OciInstanceType{testInstanceType(testShapeA, 10)},
 				instanceProvider: &FakeInstanceProvider{
-					ListInstancesFn: func(_ context.Context, _ string) ([]*ocicore.Instance, error) {
+					ListInstancesFn: func(_ context.Context, _ []string) ([]*ocicore.Instance, error) {
 						return []*ocicore.Instance{ownedLegacy, unownedLegacy}, nil
 					},
 				},
@@ -521,6 +535,30 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			nodeClaims, err := cp.List(context.Background())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nodeClaims).To(HaveLen(2))
+		})
+
+		It("should surface an aggregate compartment listing failure", func() {
+			compartmentA := testCompartmentA
+			compartmentB := testCompartmentB
+			nodeClassA := testReadyNodeClass(uniqueName("used-a"))
+			nodeClassA.Spec.NodeCompartmentId = &compartmentA
+			nodeClassB := testReadyNodeClass(uniqueName("used-b"))
+			nodeClassB.Spec.NodeCompartmentId = &compartmentB
+			nodePoolA := testNodePool(uniqueName("nodepool-a"), nodeClassA.Name)
+			nodePoolB := testNodePool(uniqueName("nodepool-b"), nodeClassB.Name)
+
+			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+				kubeClient: newFakeKubeClient(nodeClassA, nodeClassB, nodePoolA, nodePoolB),
+				instanceProvider: &FakeInstanceProvider{
+					ListInstancesFn: func(_ context.Context, compartmentIDs []string) ([]*ocicore.Instance, error) {
+						Expect(compartmentIDs).To(ConsistOf(compartmentA, compartmentB))
+						return nil, errors.New("list failed")
+					},
+				},
+			})
+
+			_, err := cp.List(context.Background())
+			Expect(err).To(MatchError("list failed"))
 		})
 
 	})
@@ -541,7 +579,7 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 			nodePool = testNodePoolWithUID("pool-a", nodeClass.Name)
 			kubeClient = newFakeKubeClient(nodeClass, nodePool)
 			nodeClaim = testNodeClaim(nodeClass.Name)
-			instanceA = testInstanceType("shape-a", 10)
+			instanceA = testInstanceType(testShapeA, 10)
 			instanceB = testInstanceType("shape-b", 20)
 			imageResult = testImageResolveResult(testImageID)
 		})
@@ -580,7 +618,7 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 				imageProvider: &FakeImageProvider{
 					ResolveImageForShapeFn: func(_ context.Context, _ *v1beta1.ImageConfig,
 						shape string) (*image.ImageResolveResult, error) {
-						if shape == "shape-a" {
+						if shape == testShapeA {
 							return nil, errors.New("shape-a image unavailable")
 						}
 						return imageResult, nil
@@ -853,16 +891,16 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 		It("should report instance drift for image mismatches", func() {
 			nodeClass := testReadyNodeClass(uniqueName("drift"))
 			desiredImage := &ocicore.Image{Id: lo.ToPtr("ocid1.image.oc1..desired")}
-			instanceType := testInstanceType("shape-a", 10)
-			instanceInfo := testInstanceWithShape("shape-a", "pool-a")
-			instanceInfo.CompartmentId = lo.ToPtr("ocid1.compartment.oc1..a")
+			instanceType := testInstanceType(testShapeA, 10)
+			instanceInfo := testInstanceWithShape(testShapeA, "pool-a")
+			instanceInfo.CompartmentId = lo.ToPtr(testCompartmentA)
 			instanceInfo.SourceDetails = ocicore.InstanceSourceViaImageDetails{
 				ImageId: lo.ToPtr("ocid1.image.oc1..actual"),
 			}
 
 			reason, err := IsInstanceDrifted(&InstanceDesiredState{
 				InstanceType:    instanceType,
-				CompartmentOcid: "ocid1.compartment.oc1..a",
+				CompartmentOcid: testCompartmentA,
 				Image:           desiredImage,
 				NodeClass:       nodeClass,
 			}, instanceInfo)
@@ -873,7 +911,7 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 		It("should return capacity reservation mismatch during drift checks when reservation config is removed", func() {
 			nodeClass := testReadyNodeClass(uniqueName("drift-nodeclass"))
 			nodeClaim := testNodeClaim(nodeClass.Name)
-			nodeClaim.Labels[corev1.LabelInstanceTypeStable] = "shape-a"
+			nodeClaim.Labels[corev1.LabelInstanceTypeStable] = testShapeA
 			nodeClaim.Spec.Requirements = append(nodeClaim.Spec.Requirements, v1.NodeSelectorRequirementWithMinValues{
 				Key:      v1beta1.ReservationIDLabel,
 				Operator: corev1.NodeSelectorOpIn,
@@ -882,7 +920,7 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 
 			cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
 				kubeClient:    newFakeKubeClient(nodeClass),
-				instanceTypes: []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+				instanceTypes: []*instancetype.OciInstanceType{testInstanceType(testShapeA, 10)},
 				imageProvider: &FakeImageProvider{
 					ResolveImageForShapeFn: func(_ context.Context, _ *v1beta1.ImageConfig,
 						_ string) (*image.ImageResolveResult, error) {
@@ -891,7 +929,7 @@ var _ = Describe("CloudProvider Unit Tests", func() {
 				},
 				instanceProvider: &FakeInstanceProvider{
 					GetInstanceCompartmentFn: func(*v1beta1.OCINodeClass) string {
-						return "ocid1.compartment.oc1..a"
+						return testCompartmentA
 					},
 				},
 			})
@@ -948,6 +986,7 @@ type unitTestCloudProviderOptions struct {
 	instanceProvider            instance.Provider
 	placementProvider           placement.Provider
 	capacityReservationProvider capacityreservation.Provider
+	blockStorageProvider        blockstorage.Provider
 	npnProvider                 npn.Provider
 	repairPolicies              []cloudprovider.RepairPolicy
 	enableServiceLimitFallback  bool
@@ -974,6 +1013,7 @@ func newUnitTestCloudProvider(opts unitTestCloudProviderOptions) *CloudProvider 
 		instanceProvider:            &FakeInstanceProvider{},
 		placementProvider:           &FakePlacementProvider{},
 		capacityReservationProvider: &FakeCapacityReservationProvider{},
+		blockStorageProvider:        &FakeBlockStorageProvider{},
 		npnProvider:                 &FakeNpnProvider{},
 		repairPolicies:              opts.repairPolicies,
 		enableServiceLimitFallback:  opts.enableServiceLimitFallback,
@@ -996,6 +1036,9 @@ func newUnitTestCloudProvider(opts unitTestCloudProviderOptions) *CloudProvider 
 	}
 	if opts.capacityReservationProvider != nil {
 		cp.capacityReservationProvider = opts.capacityReservationProvider
+	}
+	if opts.blockStorageProvider != nil {
+		cp.blockStorageProvider = opts.blockStorageProvider
 	}
 	if opts.npnProvider != nil {
 		cp.npnProvider = opts.npnProvider

--- a/pkg/cloudprovider/drift_cache_test.go
+++ b/pkg/cloudprovider/drift_cache_test.go
@@ -1,0 +1,156 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package cloudprovider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
+	ocicache "github.com/oracle/karpenter-provider-oci/pkg/cache"
+	"github.com/oracle/karpenter-provider-oci/pkg/fakes"
+	"github.com/oracle/karpenter-provider-oci/pkg/providers/blockstorage"
+	"github.com/oracle/karpenter-provider-oci/pkg/providers/instance"
+	"github.com/oracle/karpenter-provider-oci/pkg/providers/instancetype"
+	"github.com/oracle/karpenter-provider-oci/pkg/providers/network"
+	"github.com/oracle/oci-go-sdk/v65/common"
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8scorev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func TestDriftCachesLoadOnceAndEvictByInstance(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, v1beta1.AddToScheme(scheme.Scheme))
+	const (
+		instanceID  = "instance-1"
+		compartment = "compartment-1"
+		ad          = "PHX-AD-1"
+		subnetID    = "subnet-1"
+	)
+
+	nodeClass := testReadyNodeClass(uniqueName("drift-cache"))
+	nodeClass.Spec.NodeCompartmentId = lo.ToPtr(compartment)
+	nodeClass.Status.Network = &v1beta1.Network{
+		PrimaryVnic: &v1beta1.Vnic{Subnet: v1beta1.Subnet{SubnetId: subnetID}},
+	}
+	nodeClaim := testNodeClaim(nodeClass.Name)
+	nodeClaim.Labels[k8scorev1.LabelInstanceTypeStable] = "shape-a"
+	nodeClaim.Status.ProviderID = instanceID
+
+	baseInstance := testInstanceWithShape("shape-a", "pool-a")
+	baseInstance.CompartmentId = lo.ToPtr(compartment)
+	baseInstance.AvailabilityDomain = lo.ToPtr(ad)
+	computeClient := &fakes.FakeCompute{}
+	computeClient.OnGet = func(_ context.Context, request ocicore.GetInstanceRequest) (
+		ocicore.GetInstanceResponse, error) {
+		result := *baseInstance
+		result.Id = request.InstanceId
+		return ocicore.GetInstanceResponse{Instance: result, Etag: lo.ToPtr("etag-1")}, nil
+	}
+	computeClient.OnListVnics = func(_ context.Context, request ocicore.ListVnicAttachmentsRequest) (
+		ocicore.ListVnicAttachmentsResponse, error) {
+		return ocicore.ListVnicAttachmentsResponse{Items: []ocicore.VnicAttachment{{
+			VnicId:         lo.ToPtr(*request.InstanceId + "-vnic"),
+			SubnetId:       lo.ToPtr(subnetID),
+			LifecycleState: ocicore.VnicAttachmentLifecycleStateAttached,
+		}}}, nil
+	}
+	computeClient.OnListBoot = func(_ context.Context, request ocicore.ListBootVolumeAttachmentsRequest) (
+		ocicore.ListBootVolumeAttachmentsResponse, error) {
+		return ocicore.ListBootVolumeAttachmentsResponse{Items: []ocicore.BootVolumeAttachment{{
+			BootVolumeId: lo.ToPtr(*request.InstanceId + "-boot"),
+			TimeCreated:  &common.SDKTime{Time: time.Now()},
+		}}}, nil
+	}
+	computeClient.OnListInstances = func(_ context.Context, _ ocicore.ListInstancesRequest) (
+		ocicore.ListInstancesResponse, error) {
+		listed := *baseInstance
+		listed.Id = lo.ToPtr("instance-2")
+		return ocicore.ListInstancesResponse{Items: []ocicore.Instance{listed}}, nil
+	}
+
+	vcnClient := &fakes.FakeVirtualNetwork{
+		OnGetVnic: func(_ context.Context, request ocicore.GetVnicRequest) (ocicore.GetVnicResponse, error) {
+			return ocicore.GetVnicResponse{Vnic: ocicore.Vnic{
+				Id: request.VnicId, SubnetId: lo.ToPtr(subnetID), IsPrimary: lo.ToPtr(true),
+			}}, nil
+		},
+	}
+	driftCaches := instance.NewDriftCaches()
+	networkProvider, err := network.NewProvider(ctx, compartment, false, []network.IpFamily{network.IPv4},
+		vcnClient, driftCaches.VnicCache())
+	require.NoError(t, err)
+	blockClient := &fakes.FakeBlockstorage{
+		OnGetBootVolume: func(_ context.Context,
+			request ocicore.GetBootVolumeRequest) (ocicore.GetBootVolumeResponse, error) {
+			return ocicore.GetBootVolumeResponse{BootVolume: ocicore.BootVolume{Id: request.BootVolumeId}}, nil
+		},
+	}
+	blockProvider, err := blockstorage.NewProvider(ctx, blockClient, driftCaches.BootVolumeCache())
+	require.NoError(t, err)
+	instanceProvider, err := instance.NewProvider(ctx, computeClient, nil, compartment, nil, driftCaches,
+		time.Minute, time.Minute, false, time.Millisecond, ocicache.NewUnavailableOfferings(0), false)
+	require.NoError(t, err)
+
+	cp := newUnitTestCloudProvider(unitTestCloudProviderOptions{
+		kubeClient:           newFakeKubeClient(nodeClass),
+		instanceTypes:        []*instancetype.OciInstanceType{testInstanceType("shape-a", 10)},
+		instanceProvider:     instanceProvider,
+		networkProvider:      networkProvider,
+		blockStorageProvider: blockProvider,
+	})
+
+	for i := 0; i < 2; i++ {
+		reason, driftErr := cp.IsDrifted(ctx, nodeClaim)
+		require.NoError(t, driftErr)
+		assert.Empty(t, reason)
+	}
+	assertOCIReadCounts(t, computeClient, vcnClient, blockClient, 1)
+
+	loadAllDriftCaches(t, ctx, instanceProvider, networkProvider, blockProvider, "instance-2")
+	assertOCIReadCounts(t, computeClient, vcnClient, blockClient, 2)
+	_, err = instanceProvider.ListInstances(ctx, []string{compartment})
+	require.NoError(t, err)
+	assert.Equal(t, 1, computeClient.ListInstancesCount.Get())
+	assertOCIReadCounts(t, computeClient, vcnClient, blockClient, 2)
+
+	loadAllDriftCaches(t, ctx, instanceProvider, networkProvider, blockProvider, "instance-2")
+	assertOCIReadCounts(t, computeClient, vcnClient, blockClient, 2)
+	loadAllDriftCaches(t, ctx, instanceProvider, networkProvider, blockProvider, instanceID)
+	assertOCIReadCounts(t, computeClient, vcnClient, blockClient, 3)
+}
+
+func loadAllDriftCaches(t *testing.T, ctx context.Context, instanceProvider instance.Provider,
+	networkProvider network.Provider, blockProvider blockstorage.Provider, instanceID string) {
+	t.Helper()
+	_, err := instanceProvider.GetInstanceCached(ctx, instanceID)
+	require.NoError(t, err)
+	_, err = instanceProvider.ListInstanceVnicAttachmentsCached(ctx, "compartment-1", instanceID)
+	require.NoError(t, err)
+	_, err = networkProvider.GetVnicCached(ctx, instanceID+"-vnic")
+	require.NoError(t, err)
+	_, err = instanceProvider.ListInstanceBootVolumeAttachmentsCached(ctx, "compartment-1", instanceID, "PHX-AD-1")
+	require.NoError(t, err)
+	_, err = blockProvider.GetBootVolumeCached(ctx, instanceID+"-boot")
+	require.NoError(t, err)
+}
+
+func assertOCIReadCounts(t *testing.T, computeClient *fakes.FakeCompute,
+	vcnClient *fakes.FakeVirtualNetwork, blockClient *fakes.FakeBlockstorage, expected int) {
+	t.Helper()
+	assert.Equal(t, expected, computeClient.GetCount.Get())
+	assert.Equal(t, expected, computeClient.ListVnicCount.Get())
+	assert.Equal(t, expected, computeClient.ListBootCount.Get())
+	assert.Equal(t, expected, vcnClient.GetVnicCount)
+	assert.Equal(t, expected, blockClient.GetCount.Get())
+}

--- a/pkg/cloudprovider/suite_test.go
+++ b/pkg/cloudprovider/suite_test.go
@@ -130,7 +130,7 @@ type FakeInstanceProvider struct {
 	GetInstanceFn                       func(context.Context, string) (*instance.InstanceInfo, error)
 	GetInstanceCachedFn                 func(context.Context, string) (*instance.InstanceInfo, error)
 	GetInstanceCompartmentFn            func(*ocioraclecouldcomv1beta1.OCINodeClass) string
-	ListInstancesFn                     func(context.Context, string) ([]*ocicore.Instance, error)
+	ListInstancesFn                     func(context.Context, []string) ([]*ocicore.Instance, error)
 	ListInstanceBootVolumeAttachmentsFn func(context.Context, string, string, string) ([]*ocicore.BootVolumeAttachment,
 		error)
 	ListInstanceBootVolumeAttachmentsCFn func(context.Context, string, string, string) ([]*ocicore.BootVolumeAttachment,
@@ -191,9 +191,9 @@ func (ip *FakeInstanceProvider) GetInstanceCompartment(nodeClass *ocioraclecould
 }
 
 func (ip *FakeInstanceProvider) ListInstances(ctx context.Context,
-	compartmentId string) ([]*ocicore.Instance, error) {
+	compartmentIDs []string) ([]*ocicore.Instance, error) {
 	if ip.ListInstancesFn != nil {
-		return ip.ListInstancesFn(ctx, compartmentId)
+		return ip.ListInstancesFn(ctx, compartmentIDs)
 	}
 	return []*ocicore.Instance{}, nil
 }

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/computecluster"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/identity"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/image"
+	"github.com/oracle/karpenter-provider-oci/pkg/providers/instance"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/kms"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/network"
 	"github.com/samber/lo"
@@ -36,6 +37,7 @@ func TestControllers(t *testing.T) {
 var _ = Describe("OCINodeClass Reconciler", func() {
 	It("should create new controllers successfully", func() {
 		ctx := options.ToContext(context.TODO(), &options.Options{})
+		driftCaches := instance.NewDriftCaches()
 
 		nodeClassClusterCompartmentId := "ocid1.compartment.oc1..cluster123"
 
@@ -46,7 +48,8 @@ var _ = Describe("OCINodeClass Reconciler", func() {
 		kmsProvider.SetKmsClient("https://testvalut-management.kms.us-ashburn-1.oraclecloud.com", fakes.NewFakeKmsClient())
 
 		networkProvider := lo.Must(network.NewProvider(ctx, nodeClassClusterCompartmentId,
-			false, []network.IpFamily{network.IPv4}, fakes.NewFakeVirtualNetworkClient()))
+			false, []network.IpFamily{network.IPv4}, fakes.NewFakeVirtualNetworkClient(),
+			driftCaches.VnicCache()))
 		crProvider := capacityreservation.NewProvider(ctx,
 			fakes.NewFakeCapacityReservationClient(nodeClassClusterCompartmentId), nodeClassClusterCompartmentId)
 		computeClusterProvider := computecluster.NewProvider(ctx,

--- a/pkg/controllers/nodeclasses/network_reconciler_test.go
+++ b/pkg/controllers/nodeclasses/network_reconciler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
 	"github.com/oracle/karpenter-provider-oci/pkg/fakes"
+	"github.com/oracle/karpenter-provider-oci/pkg/providers/instance"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/network"
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +26,7 @@ var networkController *Controller
 
 var _ = Describe("Network Reconciler", func() {
 	BeforeEach(func() {
+		driftCaches := instance.NewDriftCaches()
 		networkTestNodeClass = fakes.CreateBasicOciNodeClass()
 		networkTestNodeClass.Spec.NetworkConfig.SecondaryVnicConfigs = []*v1beta1.SecondaryVnicConfig{
 			{
@@ -41,7 +43,7 @@ var _ = Describe("Network Reconciler", func() {
 
 		vcnClient := fakes.NewFakeVirtualNetworkClient()
 		networkProvider := lo.Must(network.NewProvider(ctx, "clusterVcnCompartmentId",
-			true, []network.IpFamily{network.IPv4}, vcnClient))
+			true, []network.IpFamily{network.IPv4}, vcnClient, driftCaches.VnicCache()))
 
 		networkController = &Controller{
 			Client:   k8sClient,

--- a/pkg/controllers/nodeclasses/ocinodeclass_controller_test.go
+++ b/pkg/controllers/nodeclasses/ocinodeclass_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/computecluster"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/identity"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/image"
+	"github.com/oracle/karpenter-provider-oci/pkg/providers/instance"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/kms"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/network"
 	"github.com/samber/lo"
@@ -32,6 +33,7 @@ var nodeClassClusterCompartmentId = "ocid1.compartment.oc1..cluster123"
 
 var _ = Describe("OCINodeClass Reconciler", func() {
 	BeforeEach(func() {
+		driftCaches := instance.NewDriftCaches()
 
 		ociTestNodeClass = fakes.CreateOciNodeClassWithMinimumReconcilableSetting(nodeClassClusterCompartmentId)
 
@@ -42,7 +44,8 @@ var _ = Describe("OCINodeClass Reconciler", func() {
 		kmsProvider.SetKmsClient("https://testvalut-management.kms.us-ashburn-1.oraclecloud.com", fakes.NewFakeKmsClient())
 
 		networkProvider := lo.Must(network.NewProvider(ctx, nodeClassClusterCompartmentId,
-			false, []network.IpFamily{network.IPv4}, fakes.NewFakeVirtualNetworkClient()))
+			false, []network.IpFamily{network.IPv4}, fakes.NewFakeVirtualNetworkClient(),
+			driftCaches.VnicCache()))
 		crProvider := capacityreservation.NewProvider(ctx,
 			fakes.NewFakeCapacityReservationClient(nodeClassClusterCompartmentId), nodeClassClusterCompartmentId)
 		computeClusterProvider := computecluster.NewProvider(ctx,

--- a/pkg/fakes/fake_vcn.go
+++ b/pkg/fakes/fake_vcn.go
@@ -153,6 +153,7 @@ type FakeVirtualNetwork struct {
 
 	// For network tests, use extended data instead of legacy TestSubnets/TestNsgs
 	UseNetworkTestData bool
+	OnGetVnic          func(context.Context, ocicore.GetVnicRequest) (ocicore.GetVnicResponse, error)
 }
 
 func (v *FakeVirtualNetwork) GetNetworkSecurityGroup(ctx context.Context,
@@ -337,6 +338,9 @@ func (v *FakeVirtualNetwork) ListNetworkSecurityGroups(ctx context.Context,
 func (v *FakeVirtualNetwork) GetVnic(ctx context.Context,
 	request ocicore.GetVnicRequest) (response ocicore.GetVnicResponse, err error) {
 	v.GetVnicCount++
+	if v.OnGetVnic != nil {
+		return v.OnGetVnic(ctx, request)
+	}
 
 	var vnic ocicore.Vnic
 	if v.UseNetworkTestData {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -141,8 +141,10 @@ func createOperator(ctx context.Context, coreOp *operator.Operator,
 		unavailableOfferings,
 		coreOp.Elected()))
 
+	driftCaches := instance.NewDriftCaches()
 	networkProvider := lo.Must(network.NewProvider(ctx, ociOptions.VcnCompartmentId,
-		ociOptions.OciVcnIpNative, ociOptions.IpFamiliesFlag.IpFamilies, ociClient))
+		ociOptions.OciVcnIpNative, ociOptions.IpFamiliesFlag.IpFamilies, ociClient,
+		driftCaches.VnicCache()))
 
 	instanceMetadataProvider := lo.Must(instancemeta.NewProvider(ctx, ociOptions.ApiserverEndpoint,
 		restConfig.TLSClientConfig.CAData, ociOptions.IpFamiliesFlag.IpFamilies))
@@ -154,7 +156,7 @@ func createOperator(ctx context.Context, coreOp *operator.Operator,
 	bmTimeout := time.Duration(ociOptions.InstanceLaunchTimeoutBMMins) * time.Minute
 	instancePollInterval := time.Duration(ociOptions.InstanceOperationPollIntervalInSeconds) * time.Second
 	instanceProvider := lo.Must(instance.NewProvider(ctx, ociClient, ociClient,
-		ociOptions.ClusterCompartmentId, instanceMetadataProvider, networkProvider,
+		ociOptions.ClusterCompartmentId, instanceMetadataProvider, driftCaches,
 		vmTimeout, bmTimeout, ociOptions.InstanceLaunchTimeOutFailOver, instancePollInterval,
 		unavailableOfferings, ociOptions.EnableUnavailableOfferingsOnServiceLimitExceeded))
 
@@ -163,7 +165,7 @@ func createOperator(ctx context.Context, coreOp *operator.Operator,
 
 	kmsKeyProvider := lo.Must(kms.NewProvider(ctx, ociOptions.ClusterCompartmentId, configProvider, &rateLimiter))
 
-	blockStorageProvider := lo.Must(blockstorage.NewProvider(ctx, ociClient))
+	blockStorageProvider := lo.Must(blockstorage.NewProvider(ctx, ociClient, driftCaches.BootVolumeCache()))
 
 	npnProvider := lo.Must(npn.NewProvider(ctx, ociOptions.OciVcnIpNative, ociOptions.IpFamiliesFlag.IpFamilies))
 	op := &Operator{

--- a/pkg/providers/blockstorage/provider.go
+++ b/pkg/providers/blockstorage/provider.go
@@ -9,11 +9,14 @@ package blockstorage
 
 import (
 	"context"
+	"errors"
 
 	"github.com/oracle/karpenter-provider-oci/pkg/cache"
 	"github.com/oracle/karpenter-provider-oci/pkg/oci"
 	ocicore "github.com/oracle/oci-go-sdk/v65/core"
 )
+
+var errBootVolumeCacheRequired = errors.New("boot volume cache is required")
 
 type Provider interface {
 	GetBootVolume(ctx context.Context, bootVolumeOcid string) (*ocicore.BootVolume, error)
@@ -25,21 +28,28 @@ type DefaultProvider struct {
 	bootVolumeCache    *cache.GetOrLoadCache[*ocicore.BootVolume]
 }
 
-func NewProvider(ctx context.Context, blockStorageClient oci.BlockStorageClient) (*DefaultProvider, error) {
+func NewProvider(ctx context.Context, blockStorageClient oci.BlockStorageClient,
+	bootVolumeCache *cache.GetOrLoadCache[*ocicore.BootVolume]) (*DefaultProvider, error) {
+	if bootVolumeCache == nil {
+		return nil, errBootVolumeCacheRequired
+	}
 	p := &DefaultProvider{
 		blockStorageClient: blockStorageClient,
-		bootVolumeCache:    cache.NewDefaultGetOrLoadCache[*ocicore.BootVolume](),
+		bootVolumeCache:    bootVolumeCache,
 	}
 
 	return p, nil
 }
 
-func (p DefaultProvider) GetBootVolume(ctx context.Context, bootVolumeOcid string) (*ocicore.BootVolume, error) {
-	p.bootVolumeCache.Evict(ctx, bootVolumeOcid)
-	return p.GetBootVolumeCached(ctx, bootVolumeOcid)
+func (p *DefaultProvider) GetBootVolume(ctx context.Context,
+	bootVolumeOcid string) (*ocicore.BootVolume, error) {
+	return p.bootVolumeCache.Refresh(ctx, bootVolumeOcid,
+		func(ctx context.Context, _ string) (*ocicore.BootVolume, error) {
+			return p.getBootVolumeImpl(ctx, bootVolumeOcid)
+		})
 }
 
-func (p DefaultProvider) getBootVolumeImpl(ctx context.Context, bootVolumeOcid string) (*ocicore.BootVolume, error) {
+func (p *DefaultProvider) getBootVolumeImpl(ctx context.Context, bootVolumeOcid string) (*ocicore.BootVolume, error) {
 	getResp, err := p.blockStorageClient.GetBootVolume(ctx, ocicore.GetBootVolumeRequest{
 		BootVolumeId: &bootVolumeOcid,
 	})
@@ -49,10 +59,11 @@ func (p DefaultProvider) getBootVolumeImpl(ctx context.Context, bootVolumeOcid s
 	return &getResp.BootVolume, nil
 }
 
-func (p *DefaultProvider) GetBootVolumeCached(ctx context.Context, bootVolumeOcid string) (*ocicore.BootVolume, error) {
+func (p *DefaultProvider) GetBootVolumeCached(ctx context.Context,
+	bootVolumeOcid string) (*ocicore.BootVolume, error) {
 	return p.bootVolumeCache.GetOrLoad(ctx, bootVolumeOcid,
-		func(ctx context.Context, key string) (*ocicore.BootVolume, error) {
-			return p.getBootVolumeImpl(ctx, key)
+		func(ctx context.Context, _ string) (*ocicore.BootVolume, error) {
+			return p.getBootVolumeImpl(ctx, bootVolumeOcid)
 
 		})
 }

--- a/pkg/providers/blockstorage/provider_test.go
+++ b/pkg/providers/blockstorage/provider_test.go
@@ -10,7 +10,6 @@ package blockstorage
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 
 	"github.com/oracle/karpenter-provider-oci/pkg/cache"
@@ -21,248 +20,58 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProvider_GetBootVolume(t *testing.T) {
-	ctx := context.TODO()
-	volId := "ocid1.bootvolume.oc1..abc123"
-	happyBootVol := ocicore.BootVolume{
-		Id:        &volId,
-		SizeInGBs: lo.ToPtr(int64(50)),
-	}
-	happyResp := ocicore.GetBootVolumeResponse{
-		BootVolume: happyBootVol,
-	}
-
-	tests := []struct {
-		name       string
-		arrange    func() DefaultProvider
-		input      string
-		want       *ocicore.BootVolume
-		wantErr    bool
-		wantGetCnt int
-	}{
-		{
-			name: "happy path",
-			arrange: func() DefaultProvider {
-				fake := &fakes.FakeBlockstorage{
-					GetBootVolumeResponse: happyResp,
-				}
-				return DefaultProvider{
-					blockStorageClient: fake,
-					bootVolumeCache:    cache.NewDefaultGetOrLoadCache[*ocicore.BootVolume](),
-				}
-			},
-			input:      volId,
-			want:       &happyBootVol,
-			wantErr:    false,
-			wantGetCnt: 1,
-		},
-		{
-			name: "error from client",
-			arrange: func() DefaultProvider {
-				fake := &fakes.FakeBlockstorage{
-					GetBootVolumeError: errors.New("not found"),
-				}
-				return DefaultProvider{
-					blockStorageClient: fake,
-					bootVolumeCache:    cache.NewDefaultGetOrLoadCache[*ocicore.BootVolume](),
-				}
-			},
-			input:      volId,
-			want:       nil,
-			wantErr:    true,
-			wantGetCnt: 1,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			provider := tt.arrange()
-			fake, _ := provider.blockStorageClient.(*fakes.FakeBlockstorage)
-			got, err := provider.GetBootVolume(ctx, tt.input)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, got)
-			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, got)
-				assert.Equal(t, tt.want, got)
+func TestBootVolumeFreshReadWritesThroughAndFailurePreservesCache(t *testing.T) {
+	ctx := context.Background()
+	current := ocicore.BootVolume{Id: lo.ToPtr("boot-volume-1"), DisplayName: lo.ToPtr("old")}
+	freshErr := errors.New("temporary cached boot volume read failure")
+	fake := &fakes.FakeBlockstorage{
+		OnGetBootVolume: func(context.Context, ocicore.GetBootVolumeRequest) (ocicore.GetBootVolumeResponse, error) {
+			if freshErr != nil {
+				return ocicore.GetBootVolumeResponse{}, freshErr
 			}
-			assert.Equal(t, tt.wantGetCnt, fake.GetCount.Get())
-		})
+			return ocicore.GetBootVolumeResponse{BootVolume: current}, nil
+		},
 	}
-}
-
-func TestProvider_GetBootVolumeCached(t *testing.T) {
-	ctx := context.TODO()
-	volId := "ocid1.bootvolume.oc1..cached"
-	bootVol := ocicore.BootVolume{
-		Id:        &volId,
-		SizeInGBs: lo.ToPtr(int64(10)),
-	}
-	resp := ocicore.GetBootVolumeResponse{
-		BootVolume: bootVol,
-	}
-
-	t.Run("caches result, only one client call", func(t *testing.T) {
-		fake := &fakes.FakeBlockstorage{
-			GetBootVolumeResponse: resp,
-		}
-		provider := &DefaultProvider{
-			blockStorageClient: fake,
-			bootVolumeCache:    cache.NewDefaultGetOrLoadCache[*ocicore.BootVolume](),
-		}
-		// First call
-		val1, err := provider.GetBootVolumeCached(ctx, volId)
-		require.NoError(t, err)
-		require.NotNil(t, val1)
-		assert.Equal(t, &bootVol, val1)
-
-		// Second call (should be from cache)
-		val2, err := provider.GetBootVolumeCached(ctx, volId)
-		require.NoError(t, err)
-		require.NotNil(t, val2)
-		assert.Equal(t, &bootVol, val2)
-
-		// Only one actual GetBootVolume call should have happened
-		assert.Equal(t, 1, fake.GetCount.Get())
-	})
-
-	t.Run("error is not cached", func(t *testing.T) {
-		fake := &fakes.FakeBlockstorage{
-			GetBootVolumeError: errors.New("exploded"),
-		}
-		provider := &DefaultProvider{
-			blockStorageClient: fake,
-			bootVolumeCache:    cache.NewDefaultGetOrLoadCache[*ocicore.BootVolume](),
-		}
-		_, err := provider.GetBootVolumeCached(ctx, volId)
-		require.Error(t, err)
-		assert.Equal(t, 1, fake.GetCount.Get())
-
-		// On retry, error should occur again (not cached)
-		_, err = provider.GetBootVolumeCached(ctx, volId)
-		require.Error(t, err)
-		assert.Equal(t, 2, fake.GetCount.Get())
-	})
-
-	t.Run("cache hit after prefill", func(t *testing.T) {
-		fake := &fakes.FakeBlockstorage{
-			GetBootVolumeResponse: resp,
-		}
-		c := cache.NewDefaultGetOrLoadCache[*ocicore.BootVolume]()
-		// Prefill cache directly
-		_, err := c.GetOrLoad(ctx, volId, func(context.Context, string) (*ocicore.BootVolume, error) {
-			return &bootVol, nil
-		})
-		require.NoError(t, err)
-
-		provider := &DefaultProvider{
-			blockStorageClient: fake,
-			bootVolumeCache:    c,
-		}
-		// Call should hit cache without calling fake
-		val, err := provider.GetBootVolumeCached(ctx, volId)
-		require.NoError(t, err)
-		assert.Equal(t, &bootVol, val)
-		assert.Equal(t, 0, fake.GetCount.Get(), "should not call client on cache hit")
-	})
-
-	t.Run("cache eviction", func(t *testing.T) {
-		fake := &fakes.FakeBlockstorage{
-			GetBootVolumeResponse: resp,
-		}
-		c := cache.NewDefaultGetOrLoadCache[*ocicore.BootVolume]()
-		provider := &DefaultProvider{
-			blockStorageClient: fake,
-			bootVolumeCache:    c,
-		}
-		// First call loads and caches
-		_, err := provider.GetBootVolumeCached(ctx, volId)
-		require.NoError(t, err)
-		assert.Equal(t, 1, fake.GetCount.Get())
-
-		// Evict manually
-		c.Evict(ctx, volId)
-
-		// Second call should load again
-		_, err = provider.GetBootVolumeCached(ctx, volId)
-		require.NoError(t, err)
-		assert.Equal(t, 2, fake.GetCount.Get(), "should call client after eviction")
-	})
-
-	t.Run("concurrent lookup single load", func(t *testing.T) {
-		fake := &fakes.FakeBlockstorage{
-			GetBootVolumeResponse: resp,
-		}
-		provider := &DefaultProvider{
-			blockStorageClient: fake,
-			bootVolumeCache:    cache.NewDefaultGetOrLoadCache[*ocicore.BootVolume](),
-		}
-
-		var wg sync.WaitGroup
-		const numGoroutines = 20
-		results := make([]*ocicore.BootVolume, numGoroutines)
-		for i := 0; i < numGoroutines; i++ {
-			wg.Add(1)
-			go func(idx int) {
-				defer wg.Done()
-				val, err := provider.GetBootVolumeCached(ctx, volId)
-				require.NoError(t, err)
-				results[idx] = val
-			}(i)
-		}
-		wg.Wait()
-
-		// All results should be the same object
-		first := results[0]
-		for _, r := range results[1:] {
-			assert.Same(t, first, r, "all should point to same cached instance")
-		}
-		assert.Equal(t, 1, fake.GetCount.Get(), "loader should execute only once")
-	})
-
-	t.Run("error then success caching", func(t *testing.T) {
-		callCount := 0
-		fake := &fakes.FakeBlockstorage{
-			OnGetBootVolume: func(context.Context, ocicore.GetBootVolumeRequest) (ocicore.GetBootVolumeResponse, error) {
-				callCount++
-				if callCount == 1 {
-					return ocicore.GetBootVolumeResponse{}, errors.New("temporary error")
-				}
-				return resp, nil
-			},
-		}
-		provider := &DefaultProvider{
-			blockStorageClient: fake,
-			bootVolumeCache:    cache.NewDefaultGetOrLoadCache[*ocicore.BootVolume](),
-		}
-
-		// First call fails, not cached
-		_, err := provider.GetBootVolumeCached(ctx, volId)
-		require.Error(t, err)
-		assert.Equal(t, 1, callCount)
-
-		// Second call succeeds, caches
-		val, err := provider.GetBootVolumeCached(ctx, volId)
-		require.NoError(t, err)
-		assert.Equal(t, &bootVol, val)
-		assert.Equal(t, 2, callCount)
-
-		// Third call from cache
-		val2, err := provider.GetBootVolumeCached(ctx, volId)
-		require.NoError(t, err)
-		assert.Equal(t, &bootVol, val2)
-		assert.Equal(t, 2, callCount, "no additional client call")
-	})
-}
-
-func TestProvider_NewProvider(t *testing.T) {
-	ctx := context.TODO()
-	fakeClient := &fakes.FakeBlockstorage{}
-
-	p, err := NewProvider(ctx, fakeClient)
+	p, err := NewProvider(ctx, fake, cache.NewNonExpiringGetOrLoadCache[*ocicore.BootVolume]())
 	require.NoError(t, err)
-	assert.NotNil(t, p)
-	assert.Equal(t, fakeClient, p.blockStorageClient)
-	assert.NotNil(t, p.bootVolumeCache)
+
+	_, err = p.GetBootVolumeCached(ctx, "boot-volume-1")
+	require.ErrorIs(t, err, freshErr)
+	assert.Equal(t, 1, fake.GetCount.Get())
+
+	freshErr = nil
+	cached, err := p.GetBootVolumeCached(ctx, "boot-volume-1")
+	require.NoError(t, err)
+	assert.Equal(t, "old", *cached.DisplayName)
+	assert.Equal(t, 2, fake.GetCount.Get())
+
+	current.DisplayName = lo.ToPtr("new")
+	cachedAgain, err := p.GetBootVolumeCached(ctx, "boot-volume-1")
+	require.NoError(t, err)
+	assert.Same(t, cached, cachedAgain)
+	assert.Equal(t, "old", *cachedAgain.DisplayName)
+	assert.Equal(t, 2, fake.GetCount.Get())
+
+	refreshed, err := p.GetBootVolume(ctx, "boot-volume-1")
+	require.NoError(t, err)
+	assert.Equal(t, "new", *refreshed.DisplayName)
+	assert.Equal(t, 3, fake.GetCount.Get())
+	cached, err = p.GetBootVolumeCached(ctx, "boot-volume-1")
+	require.NoError(t, err)
+	assert.Same(t, refreshed, cached)
+	assert.Equal(t, 3, fake.GetCount.Get())
+
+	freshErr = errors.New("temporary boot volume read failure")
+	_, err = p.GetBootVolume(ctx, "boot-volume-1")
+	require.Error(t, err)
+	assert.Equal(t, 4, fake.GetCount.Get())
+	cached, err = p.GetBootVolumeCached(ctx, "boot-volume-1")
+	require.NoError(t, err)
+	assert.Same(t, refreshed, cached)
+	assert.Equal(t, 4, fake.GetCount.Get())
+}
+
+func TestNewProviderRequiresBootVolumeCache(t *testing.T) {
+	_, err := NewProvider(context.Background(), &fakes.FakeBlockstorage{}, nil)
+	require.ErrorIs(t, err, errBootVolumeCacheRequired)
 }

--- a/pkg/providers/capacityreservation/provider.go
+++ b/pkg/providers/capacityreservation/provider.go
@@ -134,7 +134,7 @@ func (p *DefaultProvider) getUsage(capacityReservationId string) *Usage {
 
 // SyncCapacityReservation offer ability to evict capacity reservation in case it is out of sync
 func (p *DefaultProvider) SyncCapacityReservation(ctx context.Context, capacityReservationId string) error {
-	p.capResCache.Evict(ctx, capacityReservationId)
+	p.capResCache.Evict(capacityReservationId)
 	_, err := p.getCapacityReservation(ctx, capacityReservationId)
 	if err != nil {
 		return err

--- a/pkg/providers/instance/drift_cache.go
+++ b/pkg/providers/instance/drift_cache.go
@@ -1,0 +1,63 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package instance
+
+import (
+	"github.com/oracle/karpenter-provider-oci/pkg/cache"
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+)
+
+// DriftCaches owns the non-expiring instance, attachment, and child-resource
+// caches used by drift detection. Instance eviction is the root of the cleanup
+// cascade.
+type DriftCaches struct {
+	instances             *cache.GetOrLoadCache[*InstanceInfo]
+	vnicAttachments       *cache.GetOrLoadCache[[]*ocicore.VnicAttachment]
+	bootVolumeAttachments *cache.GetOrLoadCache[[]*ocicore.BootVolumeAttachment]
+	vnics                 *cache.GetOrLoadCache[*ocicore.Vnic]
+	bootVolumes           *cache.GetOrLoadCache[*ocicore.BootVolume]
+}
+
+func NewDriftCaches() *DriftCaches {
+	caches := &DriftCaches{
+		instances:             cache.NewNonExpiringGetOrLoadCache[*InstanceInfo](),
+		vnicAttachments:       cache.NewNonExpiringGetOrLoadCache[[]*ocicore.VnicAttachment](),
+		bootVolumeAttachments: cache.NewNonExpiringGetOrLoadCache[[]*ocicore.BootVolumeAttachment](),
+		vnics:                 cache.NewNonExpiringGetOrLoadCache[*ocicore.Vnic](),
+		bootVolumes:           cache.NewNonExpiringGetOrLoadCache[*ocicore.BootVolume](),
+	}
+
+	caches.instances.OnEvicted(func(instanceID string, _ *InstanceInfo) {
+		caches.vnicAttachments.Evict(instanceID)
+		caches.bootVolumeAttachments.Evict(instanceID)
+	})
+	caches.vnicAttachments.OnEvicted(func(_ string, attachments []*ocicore.VnicAttachment) {
+		for _, attachment := range attachments {
+			if attachment != nil && attachment.VnicId != nil {
+				caches.vnics.Evict(*attachment.VnicId)
+			}
+		}
+	})
+	caches.bootVolumeAttachments.OnEvicted(func(_ string, attachments []*ocicore.BootVolumeAttachment) {
+		for _, attachment := range attachments {
+			if attachment != nil && attachment.BootVolumeId != nil {
+				caches.bootVolumes.Evict(*attachment.BootVolumeId)
+			}
+		}
+	})
+
+	return caches
+}
+
+func (c *DriftCaches) VnicCache() *cache.GetOrLoadCache[*ocicore.Vnic] {
+	return c.vnics
+}
+
+func (c *DriftCaches) BootVolumeCache() *cache.GetOrLoadCache[*ocicore.BootVolume] {
+	return c.bootVolumes
+}

--- a/pkg/providers/instance/provider.go
+++ b/pkg/providers/instance/provider.go
@@ -44,6 +44,8 @@ const (
 	NodeClassHashOciFreeFormTagKey = "Karpenter_NodeClass_Hash"
 )
 
+var errDriftCachesRequired = errors.New("drift caches are required")
+
 type Provider interface {
 	LaunchInstance(ctx context.Context,
 		nodeClaim *corev1.NodeClaim,
@@ -62,7 +64,7 @@ type Provider interface {
 
 	GetInstanceCompartment(nodeClass *v1beta1.OCINodeClass) string
 
-	ListInstances(ctx context.Context, compartmentId string) ([]*ocicore.Instance, error)
+	ListInstances(ctx context.Context, compartmentIDs []string) ([]*ocicore.Instance, error)
 
 	ListInstanceBootVolumeAttachments(ctx context.Context,
 		compartmentOcid string, instanceOcid string, ad string) ([]*ocicore.BootVolumeAttachment, error)
@@ -82,7 +84,6 @@ type DefaultProvider struct {
 	workRequestClient                                oci.WorkRequestClient
 	clusterCompartmentId                             string
 	instanceMetaProvider                             instancemeta.Provider
-	networkProvider                                  network.Provider
 	instanceCache                                    *cache.GetOrLoadCache[*InstanceInfo]
 	vnicAttachCache                                  *cache.GetOrLoadCache[[]*ocicore.VnicAttachment]
 	bootVolAttachCache                               *cache.GetOrLoadCache[[]*ocicore.BootVolumeAttachment]
@@ -98,21 +99,23 @@ func NewProvider(ctx context.Context, computeClient oci.ComputeClient,
 	workRequestClient oci.WorkRequestClient,
 	clusterCompartmentId string,
 	instanceMetaProvider instancemeta.Provider,
-	networkProvider network.Provider,
+	driftCaches *DriftCaches,
 	launchTimeoutVM, launchTimeoutBM time.Duration,
 	launchTimeOutFailOver bool,
 	pollInterval time.Duration,
 	unavailableOfferings *cache.UnavailableOfferings,
 	enableUnavailableOfferingsOnServiceLimitExceeded bool) (*DefaultProvider, error) {
+	if driftCaches == nil {
+		return nil, errDriftCachesRequired
+	}
 	p := &DefaultProvider{
 		computeClient:         computeClient,
 		workRequestClient:     workRequestClient,
 		clusterCompartmentId:  clusterCompartmentId,
 		instanceMetaProvider:  instanceMetaProvider,
-		networkProvider:       networkProvider,
-		instanceCache:         cache.NewDefaultGetOrLoadCache[*InstanceInfo](),
-		vnicAttachCache:       cache.NewDefaultGetOrLoadCache[[]*ocicore.VnicAttachment](),
-		bootVolAttachCache:    cache.NewDefaultGetOrLoadCache[[]*ocicore.BootVolumeAttachment](),
+		instanceCache:         driftCaches.instances,
+		vnicAttachCache:       driftCaches.vnicAttachments,
+		bootVolAttachCache:    driftCaches.bootVolumeAttachments,
 		launchTimeoutVM:       launchTimeoutVM,
 		launchTimeoutBM:       launchTimeoutBM,
 		launchTimeOutFailOver: launchTimeOutFailOver,
@@ -288,7 +291,9 @@ func (p *DefaultProvider) LaunchInstance(ctx context.Context,
 		case <-ctx.Done():
 			return nil, errors.New("context cancelled")
 		case <-timer.C:
-			return p.instanceInProvisioningOrPlacementTimeOut(ctx, instance)
+			result, resultErr := p.instanceInProvisioningOrPlacementTimeOut(ctx, instance)
+			p.cacheInstance(result)
+			return result, resultErr
 		case <-time.After(p.pollInterval):
 			wrResp, getWrErr := p.workRequestClient.GetWorkRequest(ctx, ociwr.GetWorkRequestRequest{
 				WorkRequestId: &wrID,
@@ -300,6 +305,7 @@ func (p *DefaultProvider) LaunchInstance(ctx context.Context,
 			switch wrResp.WorkRequest.Status {
 			case ociwr.WorkRequestStatusSucceeded:
 				oci.LogWorkRequestDuration(ctx, "LaunchInstance", wrResp.WorkRequest)
+				p.cacheInstance(instance)
 				return instance, nil
 			case ociwr.WorkRequestStatusFailed, ociwr.WorkRequestStatusCanceled, ociwr.WorkRequestStatusCanceling:
 				oci.LogWorkRequestDuration(ctx, "LaunchInstance", wrResp.WorkRequest)
@@ -375,8 +381,12 @@ func (p *DefaultProvider) GetInstanceCompartment(nodeClass *v1beta1.OCINodeClass
 }
 
 func (p *DefaultProvider) GetInstance(ctx context.Context, instanceOcid string) (*InstanceInfo, error) {
-	p.instanceCache.Evict(ctx, instanceOcid)
-	return p.GetInstanceCached(ctx, instanceOcid)
+	instanceInfo, err := p.instanceCache.Refresh(ctx, instanceOcid,
+		func(ctx context.Context, key string) (*InstanceInfo, error) {
+			return p.getInstanceImpl(ctx, key)
+		})
+	p.evictInstanceIfGone(instanceOcid, instanceInfo, err)
+	return instanceInfo, err
 }
 
 func (p *DefaultProvider) getInstanceImpl(ctx context.Context, instanceOcid string) (*InstanceInfo, error) {
@@ -391,17 +401,37 @@ func (p *DefaultProvider) getInstanceImpl(ctx context.Context, instanceOcid stri
 }
 
 func (p *DefaultProvider) GetInstanceCached(ctx context.Context, instanceOcid string) (*InstanceInfo, error) {
-	return p.instanceCache.GetOrLoad(ctx, instanceOcid, func(ctx context.Context, key string) (*InstanceInfo, error) {
-		return p.getInstanceImpl(ctx, key)
-	})
+	instanceInfo, err := p.instanceCache.GetOrLoad(ctx, instanceOcid,
+		func(ctx context.Context, key string) (*InstanceInfo, error) {
+			return p.getInstanceImpl(ctx, key)
+		})
+	p.evictInstanceIfGone(instanceOcid, instanceInfo, err)
+	return instanceInfo, err
+}
+
+func (p *DefaultProvider) evictInstanceIfGone(instanceOcid string, instanceInfo *InstanceInfo, err error) {
+	if oci.IsNotFound(err) || (err == nil && IsInstanceTerminated(instanceInfo)) {
+		p.evictInstanceCaches(instanceOcid)
+	}
+}
+
+func (p *DefaultProvider) cacheInstance(instanceInfo *InstanceInfo) {
+	if p.instanceCache == nil || instanceInfo == nil || instanceInfo.Instance == nil ||
+		instanceInfo.Id == nil || IsInstanceTerminated(instanceInfo) {
+		return
+	}
+	p.instanceCache.Set(*instanceInfo.Id, instanceInfo)
 }
 
 func (p *DefaultProvider) ListInstanceVnicAttachments(ctx context.Context,
 	compartmentOcid string, instanceOcid string) ([]*ocicore.VnicAttachment, error) {
-	cacheKey := cache.MakeCompositeKey(compartmentOcid, instanceOcid)
-	p.vnicAttachCache.Evict(ctx, cacheKey)
-
-	return p.ListInstanceVnicAttachmentsCached(ctx, compartmentOcid, instanceOcid)
+	attachments, err := p.listInstanceVnicAttachmentsImpl(ctx, compartmentOcid, instanceOcid)
+	if err != nil {
+		return nil, err
+	}
+	p.vnicAttachCache.Evict(instanceOcid)
+	p.vnicAttachCache.Set(instanceOcid, attachments)
+	return attachments, nil
 }
 
 func (p *DefaultProvider) listInstanceVnicAttachmentsImpl(ctx context.Context,
@@ -431,9 +461,7 @@ func (p *DefaultProvider) listInstanceVnicAttachmentsImpl(ctx context.Context,
 
 func (p *DefaultProvider) ListInstanceVnicAttachmentsCached(ctx context.Context,
 	compartmentOcid, instanceOcid string) ([]*ocicore.VnicAttachment, error) {
-	// Use a composite key since both compartmentOcid and instanceOcid distinguish the call
-	cacheKey := cache.MakeCompositeKey(compartmentOcid, instanceOcid)
-	return p.vnicAttachCache.GetOrLoad(ctx, cacheKey,
+	return p.vnicAttachCache.GetOrLoad(ctx, instanceOcid,
 		func(ctx context.Context, key string) ([]*ocicore.VnicAttachment, error) {
 			return p.listInstanceVnicAttachmentsImpl(ctx, compartmentOcid, instanceOcid)
 		})
@@ -441,9 +469,13 @@ func (p *DefaultProvider) ListInstanceVnicAttachmentsCached(ctx context.Context,
 
 func (p *DefaultProvider) ListInstanceBootVolumeAttachments(ctx context.Context,
 	compartmentOcid string, instanceOcid string, ad string) ([]*ocicore.BootVolumeAttachment, error) {
-	cacheKey := cache.MakeCompositeKey(compartmentOcid, instanceOcid, ad)
-	p.bootVolAttachCache.Evict(ctx, cacheKey)
-	return p.ListInstanceBootVolumeAttachmentsCached(ctx, compartmentOcid, instanceOcid, ad)
+	attachments, err := p.listInstanceBootVolumeAttachmentsImpl(ctx, compartmentOcid, instanceOcid, ad)
+	if err != nil {
+		return nil, err
+	}
+	p.bootVolAttachCache.Evict(instanceOcid)
+	p.bootVolAttachCache.Set(instanceOcid, attachments)
+	return attachments, nil
 }
 
 func (p *DefaultProvider) listInstanceBootVolumeAttachmentsImpl(ctx context.Context,
@@ -475,24 +507,48 @@ func (p *DefaultProvider) listInstanceBootVolumeAttachmentsImpl(ctx context.Cont
 
 func (p *DefaultProvider) ListInstanceBootVolumeAttachmentsCached(ctx context.Context,
 	compartmentOcid, instanceOcid, ad string) ([]*ocicore.BootVolumeAttachment, error) {
-	cacheKey := cache.MakeCompositeKey(compartmentOcid, instanceOcid, ad)
-	return p.bootVolAttachCache.GetOrLoad(ctx, cacheKey,
+	return p.bootVolAttachCache.GetOrLoad(ctx, instanceOcid,
 		func(ctx context.Context, key string) ([]*ocicore.BootVolumeAttachment, error) {
 			return p.listInstanceBootVolumeAttachmentsImpl(ctx, compartmentOcid, instanceOcid, ad)
 		})
 }
 
-func (p *DefaultProvider) ListInstances(ctx context.Context, compartmentId string) ([]*ocicore.Instance, error) {
-	if compartmentId == "" {
-		log.FromContext(ctx).V(1).Info("Node compartmentId is missing, falling back to cluster compartmentId")
-		compartmentId = p.clusterCompartmentId
+func (p *DefaultProvider) ListInstances(ctx context.Context, compartmentIDs []string) ([]*ocicore.Instance, error) {
+	var instances []*ocicore.Instance
+	seenInstanceIDs := map[string]struct{}{}
+	listedCompartments := map[string]struct{}{}
+	for _, compartmentID := range compartmentIDs {
+		if compartmentID == "" {
+			log.FromContext(ctx).V(1).Info("Node compartmentId is missing, falling back to cluster compartmentId")
+			compartmentID = p.clusterCompartmentId
+		}
+		if _, listed := listedCompartments[compartmentID]; listed {
+			continue
+		}
+		listedCompartments[compartmentID] = struct{}{}
+
+		listed, err := p.listInstances(ctx, compartmentID)
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, listed...)
+		for _, item := range listed {
+			if item.Id != nil {
+				seenInstanceIDs[*item.Id] = struct{}{}
+			}
+		}
 	}
 
+	p.evictUnseenInstanceCaches(seenInstanceIDs)
+	return instances, nil
+}
+
+func (p *DefaultProvider) listInstances(ctx context.Context, compartmentID string) ([]*ocicore.Instance, error) {
 	var page *string
 	var instances []*ocicore.Instance
 	for {
 		resp, err := p.computeClient.ListInstances(ctx, ocicore.ListInstancesRequest{
-			CompartmentId: &compartmentId,
+			CompartmentId: &compartmentID,
 			Limit:         common.Int(100),
 			Page:          page,
 		})
@@ -501,18 +557,17 @@ func (p *DefaultProvider) ListInstances(ctx context.Context, compartmentId strin
 			return nil, err
 		}
 
-		instances = append(instances, lo.ToSlicePtr(lo.Filter(resp.Items, func(item ocicore.Instance, _ int) bool {
+		for i := range resp.Items {
+			item := &resp.Items[i]
+			if _, ok := GetNodePoolNameFromInstance(item); !ok || item.Id == nil {
+				continue
+			}
 			if item.LifecycleState == ocicore.InstanceLifecycleStateTerminated {
-				return false
+				continue
 			}
-
-			// filter out instance that has no node pool name
-			if _, ok := GetNodePoolNameFromInstance(&item); ok {
-				return true
-			}
-
-			return false
-		}))...)
+			instances = append(instances, item)
+			p.cacheInstance(&InstanceInfo{Instance: item})
+		}
 
 		page = resp.OpcNextPage
 		if page == nil {
@@ -523,11 +578,44 @@ func (p *DefaultProvider) ListInstances(ctx context.Context, compartmentId strin
 	return instances, nil
 }
 
+func (p *DefaultProvider) evictInstanceCaches(instanceOcid string) {
+	if p.instanceCache != nil {
+		p.instanceCache.Evict(instanceOcid)
+	}
+	if p.vnicAttachCache != nil {
+		p.vnicAttachCache.Evict(instanceOcid)
+	}
+	if p.bootVolAttachCache != nil {
+		p.bootVolAttachCache.Evict(instanceOcid)
+	}
+}
+
+// evictUnseenInstanceCaches removes all instance-scoped cache entries whose instance IDs were not
+// observed during a complete ListInstances call.
+func (p *DefaultProvider) evictUnseenInstanceCaches(seenInstanceIDs map[string]struct{}) {
+	evictUnseen := func(instanceID string) bool {
+		_, seen := seenInstanceIDs[instanceID]
+		return !seen
+	}
+	if p.instanceCache != nil {
+		p.instanceCache.EvictMatching(evictUnseen)
+	}
+	if p.vnicAttachCache != nil {
+		p.vnicAttachCache.EvictMatching(evictUnseen)
+	}
+	if p.bootVolAttachCache != nil {
+		p.bootVolAttachCache.EvictMatching(evictUnseen)
+	}
+}
+
 func (p *DefaultProvider) DeleteInstance(ctx context.Context, instanceOcid string) error {
 	_, err := p.computeClient.TerminateInstance(ctx, ocicore.TerminateInstanceRequest{
 		InstanceId: &instanceOcid,
 	})
 	if err != nil {
+		if oci.IsNotFound(err) {
+			p.evictInstanceCaches(instanceOcid)
+		}
 		return err
 	}
 

--- a/pkg/providers/instance/provider_test.go
+++ b/pkg/providers/instance/provider_test.go
@@ -217,6 +217,12 @@ func TestProvider_GetInstanceCompartment(t *testing.T) {
 	}
 }
 
+func TestNewProviderRequiresDriftCaches(t *testing.T) {
+	_, err := NewProvider(context.Background(), nil, nil, "", nil, nil,
+		0, 0, false, 0, nil, false)
+	require.ErrorIs(t, err, errDriftCachesRequired)
+}
+
 func TestProvider_IsInstanceTerminated(t *testing.T) {
 	tests := []struct {
 		name string
@@ -599,131 +605,446 @@ func TestProvider_BuildCreateVnicDetails(t *testing.T) {
 	}
 }
 
-func TestProvider_Cached_Wrappers(t *testing.T) {
+func TestProvider_FreshReadFailuresPreserveCachedDriftValues(t *testing.T) {
+	ctx := context.Background()
+	failFreshReads := false
+	instanceDisplayName := "old"
+	vnicID := "vnic-1"
+	bootVolumeID := "boot-volume-1"
 	fc := &fakes.FakeCompute{}
-	// Provide canned responses via hooks
-	fc.OnGet = func(ctx context.Context, r ocicore.GetInstanceRequest) (ocicore.GetInstanceResponse, error) {
-		return ocicore.GetInstanceResponse{
-			Instance: ocicore.Instance{
-				Id:                 lo.ToPtr("ocid1.instance.oc1..xyz"),
-				DisplayName:        lo.ToPtr("inst1"),
-				AvailabilityDomain: lo.ToPtr("tenancy:PHX-AD-1"),
-				LifecycleState:     ocicore.InstanceLifecycleStateRunning,
-				SourceDetails:      ocicore.InstanceSourceViaImageDetails{ImageId: lo.ToPtr("ocid1.image.oc1..img")},
-			},
-			Etag: lo.ToPtr("etag-1"),
-		}, nil
-	}
-	fc.OnListVnics = func(ctx context.Context, r ocicore.ListVnicAttachmentsRequest) (
-		ocicore.ListVnicAttachmentsResponse, error) {
-		return ocicore.ListVnicAttachmentsResponse{
-			Items: []ocicore.VnicAttachment{{Id: lo.ToPtr("ocid1.vnicattach.oc1..1")}}}, nil
-	}
-	fc.OnListBoot = func(ctx context.Context, r ocicore.ListBootVolumeAttachmentsRequest) (
-		ocicore.ListBootVolumeAttachmentsResponse, error) {
-		return ocicore.ListBootVolumeAttachmentsResponse{
-			Items: []ocicore.BootVolumeAttachment{{Id: lo.ToPtr("ocid1.bootvolattach.oc1..1")}}}, nil
-	}
-
-	p := &DefaultProvider{
-		computeClient:      fc,
-		instanceCache:      cache.NewDefaultGetOrLoadCache[*InstanceInfo](),
-		vnicAttachCache:    cache.NewDefaultGetOrLoadCache[[]*ocicore.VnicAttachment](),
-		bootVolAttachCache: cache.NewDefaultGetOrLoadCache[[]*ocicore.BootVolumeAttachment](),
-		launchTimeoutVM:    10 * time.Minute,
-		launchTimeoutBM:    20 * time.Minute,
-	}
-
-	ctx := context.TODO()
-
-	// GetInstanceCached - invoke twice -> underlying GetInstance once
-	{
-		i1, err := p.GetInstanceCached(ctx, "ocid1.instance.oc1..xyz")
-		assert.NoError(t, err)
-		assert.Equal(t, "ocid1.instance.oc1..xyz", *i1.Id)
-
-		i2, err := p.GetInstanceCached(ctx, "ocid1.instance.oc1..xyz")
-		assert.NoError(t, err)
-		assert.Equal(t, "ocid1.instance.oc1..xyz", *i2.Id)
-
-		assert.Equal(t, 1, fc.GetCount.Get(), "expected GetInstance called once due to caching")
-	}
-
-	// ListInstanceVnicAttachmentsCached - invoke twice -> underlying list once
-	{
-		va1, err := p.ListInstanceVnicAttachmentsCached(ctx, "ocid1.compartment.oc1..c", "ocid1.instance.oc1..xyz")
-		assert.NoError(t, err)
-		assert.Len(t, va1, 1)
-
-		va2, err := p.ListInstanceVnicAttachmentsCached(ctx, "ocid1.compartment.oc1..c", "ocid1.instance.oc1..xyz")
-		assert.NoError(t, err)
-		assert.Len(t, va2, 1)
-
-		assert.Equal(t, 1, fc.ListVnicCount.Get(), "expected ListVnicAttachments called once due to caching")
-	}
-
-	// ListInstanceBootVolumeAttachmentsCached - invoke twice -> underlying list once
-	{
-		bv1, err := p.ListInstanceBootVolumeAttachmentsCached(ctx, "ocid1.compartment.oc1..c",
-			"ocid1.instance.oc1..xyz", "tenancy:PHX-AD-1")
-		assert.NoError(t, err)
-		assert.Len(t, bv1, 1)
-
-		bv2, err := p.ListInstanceBootVolumeAttachmentsCached(ctx, "ocid1.compartment.oc1..c",
-			"ocid1.instance.oc1..xyz", "tenancy:PHX-AD-1")
-		assert.NoError(t, err)
-		assert.Len(t, bv2, 1)
-
-		assert.Equal(t, 1, fc.ListBootCount.Get(), "expected ListBootVolumeAttachments called once due to caching")
-	}
-}
-
-func TestProvider_Get_List_Delete_WithFakeCompute(t *testing.T) {
-	// unified fake compute with hooks returning canned responses
-	fc := &fakes.FakeCompute{}
-	terminated := new(bool)
-	fc.OnGet = func(ctx context.Context, r ocicore.GetInstanceRequest) (ocicore.GetInstanceResponse, error) {
-		state := ocicore.InstanceLifecycleStateRunning
-		if *terminated && r.InstanceId != nil && *r.InstanceId == "ocid1.instance.oc1..xyz" {
-			state = ocicore.InstanceLifecycleStateTerminated
+	fc.OnGet = func(context.Context, ocicore.GetInstanceRequest) (ocicore.GetInstanceResponse, error) {
+		if failFreshReads {
+			return ocicore.GetInstanceResponse{}, errors.New("temporary instance read failure")
 		}
 		return ocicore.GetInstanceResponse{
 			Instance: ocicore.Instance{
-				Id:                 lo.ToPtr("ocid1.instance.oc1..xyz"),
-				DisplayName:        lo.ToPtr("inst1"),
-				AvailabilityDomain: lo.ToPtr("tenancy:PHX-AD-1"),
-				LifecycleState:     state,
-				SourceDetails:      ocicore.InstanceSourceViaImageDetails{ImageId: lo.ToPtr("ocid1.image.oc1..img")},
-				TimeCreated:        &common.SDKTime{Time: time.Now()},
+				Id:             lo.ToPtr("instance-1"),
+				DisplayName:    lo.ToPtr(instanceDisplayName),
+				LifecycleState: ocicore.InstanceLifecycleStateRunning,
 			},
 			Etag: lo.ToPtr("etag-1"),
 		}, nil
 	}
-	// In OnTerminate, flip the terminated switch
-	fc.OnTerminate = func(ctx context.Context, r ocicore.TerminateInstanceRequest) (
-		ocicore.TerminateInstanceResponse, error) {
-		*terminated = true
-		return ocicore.TerminateInstanceResponse{}, nil
-	}
-	// (No duplicate assignment here!)
-	fc.OnListVnics = func(ctx context.Context, r ocicore.ListVnicAttachmentsRequest) (
+	fc.OnListVnics = func(context.Context, ocicore.ListVnicAttachmentsRequest) (
 		ocicore.ListVnicAttachmentsResponse, error) {
-		return ocicore.ListVnicAttachmentsResponse{
-			Items: []ocicore.VnicAttachment{{Id: lo.ToPtr("ocid1.vnicattach.oc1..1")}},
-		}, nil
+		if failFreshReads {
+			return ocicore.ListVnicAttachmentsResponse{}, errors.New("temporary VNIC attachment read failure")
+		}
+		return ocicore.ListVnicAttachmentsResponse{Items: []ocicore.VnicAttachment{{
+			VnicId: lo.ToPtr(vnicID),
+		}}}, nil
 	}
-	fc.OnListBoot = func(ctx context.Context, r ocicore.ListBootVolumeAttachmentsRequest) (
+	fc.OnListBoot = func(context.Context, ocicore.ListBootVolumeAttachmentsRequest) (
 		ocicore.ListBootVolumeAttachmentsResponse, error) {
-		return ocicore.ListBootVolumeAttachmentsResponse{
-			Items: []ocicore.BootVolumeAttachment{{Id: lo.ToPtr("ocid1.bootvolattach.oc1..1")}},
-		}, nil
+		if failFreshReads {
+			return ocicore.ListBootVolumeAttachmentsResponse{}, errors.New("temporary boot attachment read failure")
+		}
+		return ocicore.ListBootVolumeAttachmentsResponse{Items: []ocicore.BootVolumeAttachment{{
+			BootVolumeId: lo.ToPtr(bootVolumeID),
+		}}}, nil
 	}
-	fc.OnListInstances = func(ctx context.Context, r ocicore.ListInstancesRequest) (ocicore.ListInstancesResponse, error) {
+
+	driftCaches := NewDriftCaches()
+	p := &DefaultProvider{
+		computeClient:      fc,
+		instanceCache:      driftCaches.instances,
+		vnicAttachCache:    driftCaches.vnicAttachments,
+		bootVolAttachCache: driftCaches.bootVolumeAttachments,
+	}
+
+	instanceInfo, err := p.GetInstanceCached(ctx, "instance-1")
+	require.NoError(t, err)
+	vnicAttachments, err := p.ListInstanceVnicAttachmentsCached(ctx, "compartment-1", "instance-1")
+	require.NoError(t, err)
+	bootAttachments, err := p.ListInstanceBootVolumeAttachmentsCached(ctx, "compartment-1", "instance-1", "ad-1")
+	require.NoError(t, err)
+	assert.Equal(t, "old", *instanceInfo.DisplayName)
+	assert.Equal(t, "vnic-1", *vnicAttachments[0].VnicId)
+	assert.Equal(t, "boot-volume-1", *bootAttachments[0].BootVolumeId)
+	assert.Equal(t, 1, fc.GetCount.Get())
+	assert.Equal(t, 1, fc.ListVnicCount.Get())
+	assert.Equal(t, 1, fc.ListBootCount.Get())
+	oldVnic := &ocicore.Vnic{Id: lo.ToPtr(vnicID)}
+	oldBootVolume := &ocicore.BootVolume{Id: lo.ToPtr(bootVolumeID)}
+	driftCaches.vnics.Set(vnicID, oldVnic)
+	driftCaches.bootVolumes.Set(bootVolumeID, oldBootVolume)
+
+	instanceDisplayName = "new"
+	vnicID = "vnic-2"
+	bootVolumeID = "boot-volume-2"
+	cachedInstance, err := p.GetInstanceCached(ctx, "instance-1")
+	require.NoError(t, err)
+	assert.Same(t, instanceInfo, cachedInstance)
+	cachedVnicAttachments, err := p.ListInstanceVnicAttachmentsCached(ctx, "compartment-1", "instance-1")
+	require.NoError(t, err)
+	assert.Equal(t, vnicAttachments, cachedVnicAttachments)
+	cachedBootAttachments, err := p.ListInstanceBootVolumeAttachmentsCached(ctx, "compartment-1", "instance-1", "ad-1")
+	require.NoError(t, err)
+	assert.Equal(t, bootAttachments, cachedBootAttachments)
+	assert.Equal(t, 1, fc.GetCount.Get())
+	assert.Equal(t, 1, fc.ListVnicCount.Get())
+	assert.Equal(t, 1, fc.ListBootCount.Get())
+
+	instanceInfo, err = p.GetInstance(ctx, "instance-1")
+	require.NoError(t, err)
+	vnicAttachments, err = p.ListInstanceVnicAttachments(ctx, "compartment-1", "instance-1")
+	require.NoError(t, err)
+	bootAttachments, err = p.ListInstanceBootVolumeAttachments(ctx, "compartment-1", "instance-1", "ad-1")
+	require.NoError(t, err)
+	assert.Equal(t, "new", *instanceInfo.DisplayName)
+	assert.Equal(t, "vnic-2", *vnicAttachments[0].VnicId)
+	assert.Equal(t, "boot-volume-2", *bootAttachments[0].BootVolumeId)
+	assert.Equal(t, 2, fc.GetCount.Get())
+	assert.Equal(t, 2, fc.ListVnicCount.Get())
+	assert.Equal(t, 2, fc.ListBootCount.Get())
+	assertCacheEntryReloads(t, ctx, driftCaches.vnics, "vnic-1", oldVnic)
+	assertCacheEntryReloads(t, ctx, driftCaches.bootVolumes, "boot-volume-1", oldBootVolume)
+	driftCaches.vnics.Evict("vnic-1")
+	driftCaches.bootVolumes.Evict("boot-volume-1")
+	newVnic := &ocicore.Vnic{Id: lo.ToPtr("vnic-2")}
+	newBootVolume := &ocicore.BootVolume{Id: lo.ToPtr("boot-volume-2")}
+	driftCaches.vnics.Set("vnic-2", newVnic)
+	driftCaches.bootVolumes.Set("boot-volume-2", newBootVolume)
+
+	failFreshReads = true
+	_, err = p.GetInstance(ctx, "instance-1")
+	require.Error(t, err)
+	_, err = p.ListInstanceVnicAttachments(ctx, "compartment-1", "instance-1")
+	require.Error(t, err)
+	_, err = p.ListInstanceBootVolumeAttachments(ctx, "compartment-1", "instance-1", "ad-1")
+	require.Error(t, err)
+	assert.Equal(t, 3, fc.GetCount.Get())
+	assert.Equal(t, 3, fc.ListVnicCount.Get())
+	assert.Equal(t, 3, fc.ListBootCount.Get())
+
+	cachedInstance, err = p.GetInstanceCached(ctx, "instance-1")
+	require.NoError(t, err)
+	assert.Same(t, instanceInfo, cachedInstance)
+	cachedVnicAttachments, err = p.ListInstanceVnicAttachmentsCached(ctx, "compartment-1", "instance-1")
+	require.NoError(t, err)
+	assert.Equal(t, vnicAttachments, cachedVnicAttachments)
+	cachedBootAttachments, err = p.ListInstanceBootVolumeAttachmentsCached(ctx, "compartment-1", "instance-1", "ad-1")
+	require.NoError(t, err)
+	assert.Equal(t, bootAttachments, cachedBootAttachments)
+	assertCacheEntryRetained(t, ctx, driftCaches.vnics, "vnic-2", newVnic)
+	assertCacheEntryRetained(t, ctx, driftCaches.bootVolumes, "boot-volume-2", newBootVolume)
+	assert.Equal(t, 3, fc.GetCount.Get())
+	assert.Equal(t, 3, fc.ListVnicCount.Get())
+	assert.Equal(t, 3, fc.ListBootCount.Get())
+}
+
+func TestProvider_InstanceReadsEvictGoneInstances(t *testing.T) {
+	testCases := []struct {
+		name       string
+		cachedRead bool
+		notFound   bool
+	}{
+		{name: "fresh NotFound", notFound: true},
+		{name: "fresh terminated"},
+		{name: "cached NotFound", cachedRead: true, notFound: true},
+		{name: "cached terminated", cachedRead: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			const instanceID = "instance-gone"
+			driftCaches := NewDriftCaches()
+			entries := driftCacheEntriesForInstance(instanceID)
+			if testCase.cachedRead {
+				seedDriftChildCacheEntries(driftCaches, instanceID, entries)
+			} else {
+				seedDriftCacheEntries(driftCaches, instanceID)
+			}
+			fc := &fakes.FakeCompute{
+				OnGet: func(context.Context, ocicore.GetInstanceRequest) (ocicore.GetInstanceResponse, error) {
+					if testCase.notFound {
+						return ocicore.GetInstanceResponse{}, fakeServiceError{
+							httpStatus: http.StatusNotFound,
+							code:       "NotAuthorizedOrNotFound",
+							message:    "missing",
+						}
+					}
+					terminated := *entries.instance.Instance
+					terminated.LifecycleState = ocicore.InstanceLifecycleStateTerminated
+					return ocicore.GetInstanceResponse{Instance: terminated, Etag: lo.ToPtr("etag")}, nil
+				},
+			}
+			p := &DefaultProvider{
+				computeClient:      fc,
+				instanceCache:      driftCaches.instances,
+				vnicAttachCache:    driftCaches.vnicAttachments,
+				bootVolAttachCache: driftCaches.bootVolumeAttachments,
+			}
+
+			var err error
+			if testCase.cachedRead {
+				_, err = p.GetInstanceCached(ctx, instanceID)
+			} else {
+				_, err = p.GetInstance(ctx, instanceID)
+			}
+			if testCase.notFound {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assertDriftCacheEntriesEvicted(t, ctx, driftCaches, entries)
+		})
+	}
+}
+
+func TestProvider_DeleteInstanceEvictsDriftCaches(t *testing.T) {
+	testCases := []struct {
+		name              string
+		terminateNotFound bool
+	}{
+		{name: "terminate NotFound", terminateNotFound: true},
+		{name: "completed termination"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+			const instanceID = "instance-deleted"
+			driftCaches := NewDriftCaches()
+			entries := seedDriftCacheEntries(driftCaches, instanceID)
+			fc := &fakes.FakeCompute{
+				OnTerminate: func(context.Context, ocicore.TerminateInstanceRequest) (
+					ocicore.TerminateInstanceResponse, error) {
+					if testCase.terminateNotFound {
+						return ocicore.TerminateInstanceResponse{}, fakeServiceError{
+							httpStatus: http.StatusNotFound,
+							code:       "NotAuthorizedOrNotFound",
+							message:    "missing",
+						}
+					}
+					return ocicore.TerminateInstanceResponse{}, nil
+				},
+				OnGet: func(context.Context, ocicore.GetInstanceRequest) (ocicore.GetInstanceResponse, error) {
+					terminated := *entries.instance.Instance
+					terminated.LifecycleState = ocicore.InstanceLifecycleStateTerminated
+					return ocicore.GetInstanceResponse{Instance: terminated, Etag: lo.ToPtr("etag")}, nil
+				},
+			}
+			p := &DefaultProvider{
+				computeClient:      fc,
+				instanceCache:      driftCaches.instances,
+				vnicAttachCache:    driftCaches.vnicAttachments,
+				bootVolAttachCache: driftCaches.bootVolumeAttachments,
+				pollInterval:       time.Millisecond,
+			}
+
+			err := p.DeleteInstance(ctx, instanceID)
+			if testCase.terminateNotFound {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Zero(t, fc.ListVnicCount.Get())
+			assert.Zero(t, fc.ListBootCount.Get())
+			assertDriftCacheEntriesEvicted(t, ctx, driftCaches, entries)
+		})
+	}
+}
+
+func TestProvider_ListInstancesAggregatesAndEvictsUnseen(t *testing.T) {
+	ctx := context.Background()
+	const (
+		clusterCompartment = "compartment-cluster"
+		otherCompartment   = "compartment-other"
+		seenInstanceAID    = "instance-seen-a"
+		seenInstanceBID    = "instance-seen-b"
+		unseenInstanceID   = "instance-unseen"
+		orphanInstanceID   = "instance-orphan"
+	)
+	driftCaches := NewDriftCaches()
+	seenA := seedDriftCacheEntries(driftCaches, seenInstanceAID)
+	seenB := driftCacheEntriesForInstance(seenInstanceBID)
+	unseen := seedDriftCacheEntries(driftCaches, unseenInstanceID)
+	orphan := driftCacheEntriesForInstance(orphanInstanceID)
+	seedDriftChildCacheEntries(driftCaches, orphanInstanceID, orphan)
+	fc := &fakes.FakeCompute{
+		OnListInstances: func(_ context.Context,
+			request ocicore.ListInstancesRequest) (ocicore.ListInstancesResponse, error) {
+			switch lo.FromPtr(request.CompartmentId) {
+			case clusterCompartment:
+				return ocicore.ListInstancesResponse{Items: []ocicore.Instance{*seenA.instance.Instance}}, nil
+			case otherCompartment:
+				return ocicore.ListInstancesResponse{Items: []ocicore.Instance{*seenB.instance.Instance}}, nil
+			default:
+				return ocicore.ListInstancesResponse{}, fmt.Errorf("unexpected compartment")
+			}
+		},
+	}
+	p := &DefaultProvider{
+		computeClient:        fc,
+		clusterCompartmentId: clusterCompartment,
+		instanceCache:        driftCaches.instances,
+		vnicAttachCache:      driftCaches.vnicAttachments,
+		bootVolAttachCache:   driftCaches.bootVolumeAttachments,
+	}
+
+	instances, err := p.ListInstances(ctx, []string{
+		"", clusterCompartment, "", otherCompartment, otherCompartment,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, fc.ListInstancesCount.Get())
+	assert.ElementsMatch(t, []string{seenInstanceAID, seenInstanceBID},
+		lo.Map(instances, func(item *ocicore.Instance, _ int) string { return lo.FromPtr(item.Id) }))
+	assertDriftCacheEntriesRetained(t, ctx, driftCaches, seenA)
+	assertCacheEntryRetained(t, ctx, driftCaches.instances, seenInstanceBID, seenB.instance)
+	assertDriftCacheEntriesEvicted(t, ctx, driftCaches, unseen)
+	assertDriftCacheEntriesEvicted(t, ctx, driftCaches, orphan)
+}
+
+func TestProvider_ListInstancesFailureDoesNotPrune(t *testing.T) {
+	ctx := context.Background()
+	driftCaches := NewDriftCaches()
+	retained := seedDriftCacheEntries(driftCaches, "instance-retained")
+	listed := driftCacheEntriesForInstance("instance-listed")
+	fc := &fakes.FakeCompute{
+		OnListInstances: func(_ context.Context,
+			request ocicore.ListInstancesRequest) (ocicore.ListInstancesResponse, error) {
+			if lo.FromPtr(request.CompartmentId) == "compartment-b" {
+				return ocicore.ListInstancesResponse{}, errors.New("list failed")
+			}
+			return ocicore.ListInstancesResponse{Items: []ocicore.Instance{*listed.instance.Instance}}, nil
+		},
+	}
+	p := &DefaultProvider{
+		computeClient:      fc,
+		instanceCache:      driftCaches.instances,
+		vnicAttachCache:    driftCaches.vnicAttachments,
+		bootVolAttachCache: driftCaches.bootVolumeAttachments,
+	}
+
+	_, err := p.ListInstances(ctx, []string{"compartment-a", "compartment-b"})
+	require.EqualError(t, err, "list failed")
+	assert.Equal(t, 2, fc.ListInstancesCount.Get())
+	assertDriftCacheEntriesRetained(t, ctx, driftCaches, retained)
+	assertCacheEntryRetained(t, ctx, driftCaches.instances, "instance-listed", listed.instance)
+}
+
+func TestProvider_ListInstancesEmptyScopeEvictsAll(t *testing.T) {
+	ctx := context.Background()
+	driftCaches := NewDriftCaches()
+	cached := seedDriftCacheEntries(driftCaches, "instance-cached")
+	orphan := driftCacheEntriesForInstance("instance-orphan")
+	seedDriftChildCacheEntries(driftCaches, "instance-orphan", orphan)
+	fc := &fakes.FakeCompute{}
+	p := &DefaultProvider{
+		computeClient:      fc,
+		instanceCache:      driftCaches.instances,
+		vnicAttachCache:    driftCaches.vnicAttachments,
+		bootVolAttachCache: driftCaches.bootVolumeAttachments,
+	}
+
+	instances, err := p.ListInstances(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, instances)
+	assert.Zero(t, fc.ListInstancesCount.Get())
+	assertDriftCacheEntriesEvicted(t, ctx, driftCaches, cached)
+	assertDriftCacheEntriesEvicted(t, ctx, driftCaches, orphan)
+}
+
+type driftCacheEntries struct {
+	instance              *InstanceInfo
+	vnicAttachments       []*ocicore.VnicAttachment
+	bootVolumeAttachments []*ocicore.BootVolumeAttachment
+	vnic                  *ocicore.Vnic
+	bootVolume            *ocicore.BootVolume
+}
+
+func driftCacheEntriesForInstance(instanceID string) driftCacheEntries {
+	vnicID := instanceID + "-vnic"
+	bootVolumeID := instanceID + "-boot"
+	return driftCacheEntries{
+		instance: &InstanceInfo{Instance: &ocicore.Instance{
+			Id:             lo.ToPtr(instanceID),
+			LifecycleState: ocicore.InstanceLifecycleStateRunning,
+			FreeformTags:   map[string]string{NodePoolOciFreeFormTagKey: "nodepool"},
+		}},
+		vnicAttachments: []*ocicore.VnicAttachment{{VnicId: lo.ToPtr(vnicID)}},
+		bootVolumeAttachments: []*ocicore.BootVolumeAttachment{{
+			BootVolumeId: lo.ToPtr(bootVolumeID),
+		}},
+		vnic:       &ocicore.Vnic{Id: lo.ToPtr(vnicID)},
+		bootVolume: &ocicore.BootVolume{Id: lo.ToPtr(bootVolumeID)},
+	}
+}
+
+func seedDriftCacheEntries(caches *DriftCaches, instanceID string) driftCacheEntries {
+	entries := driftCacheEntriesForInstance(instanceID)
+	caches.instances.Set(instanceID, entries.instance)
+	seedDriftChildCacheEntries(caches, instanceID, entries)
+	return entries
+}
+
+func seedDriftChildCacheEntries(caches *DriftCaches, instanceID string, entries driftCacheEntries) {
+	caches.vnicAttachments.Set(instanceID, entries.vnicAttachments)
+	caches.bootVolumeAttachments.Set(instanceID, entries.bootVolumeAttachments)
+	caches.vnics.Set(lo.FromPtr(entries.vnic.Id), entries.vnic)
+	caches.bootVolumes.Set(lo.FromPtr(entries.bootVolume.Id), entries.bootVolume)
+}
+
+func assertDriftCacheEntriesRetained(t *testing.T, ctx context.Context, caches *DriftCaches,
+	entries driftCacheEntries) {
+	t.Helper()
+	instanceID := lo.FromPtr(entries.instance.Id)
+	assertCacheEntryRetained(t, ctx, caches.instances, instanceID, entries.instance)
+	assertCacheEntryRetained(t, ctx, caches.vnicAttachments, instanceID, entries.vnicAttachments)
+	assertCacheEntryRetained(t, ctx, caches.bootVolumeAttachments, instanceID, entries.bootVolumeAttachments)
+	assertCacheEntryRetained(t, ctx, caches.vnics, lo.FromPtr(entries.vnic.Id), entries.vnic)
+	assertCacheEntryRetained(t, ctx, caches.bootVolumes, lo.FromPtr(entries.bootVolume.Id), entries.bootVolume)
+}
+
+func assertDriftCacheEntriesEvicted(t *testing.T, ctx context.Context, caches *DriftCaches,
+	entries driftCacheEntries) {
+	t.Helper()
+	instanceID := lo.FromPtr(entries.instance.Id)
+	assertCacheEntryReloads(t, ctx, caches.instances, instanceID, entries.instance)
+	assertCacheEntryReloads(t, ctx, caches.vnicAttachments, instanceID, entries.vnicAttachments)
+	assertCacheEntryReloads(t, ctx, caches.bootVolumeAttachments, instanceID, entries.bootVolumeAttachments)
+	assertCacheEntryReloads(t, ctx, caches.vnics, lo.FromPtr(entries.vnic.Id), entries.vnic)
+	assertCacheEntryReloads(t, ctx, caches.bootVolumes, lo.FromPtr(entries.bootVolume.Id), entries.bootVolume)
+}
+
+func assertCacheEntryReloads[T any](t *testing.T, ctx context.Context, c *cache.GetOrLoadCache[T],
+	key string, value T) {
+	t.Helper()
+	loads := 0
+	_, err := c.GetOrLoad(ctx, key, func(context.Context, string) (T, error) {
+		loads++
+		return value, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, loads)
+}
+
+func assertCacheEntryRetained[T any](t *testing.T, ctx context.Context, c *cache.GetOrLoadCache[T],
+	key string, value T) {
+	t.Helper()
+	loads := 0
+	loaded, err := c.GetOrLoad(ctx, key, func(context.Context, string) (T, error) {
+		loads++
+		return value, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, value, loaded)
+	assert.Zero(t, loads)
+}
+
+func TestProvider_ListInstancesFiltersAndWritesThrough(t *testing.T) {
+	fc := &fakes.FakeCompute{}
+	fc.OnListInstances = func(context.Context,
+		ocicore.ListInstancesRequest) (ocicore.ListInstancesResponse, error) {
 		return ocicore.ListInstancesResponse{
 			Items: []ocicore.Instance{
 				{Id: lo.ToPtr("ocid1.instance.oc1..term"), DisplayName: lo.ToPtr("term"),
 					AvailabilityDomain: lo.ToPtr("tenancy:PHX-AD-1"),
-					LifecycleState:     ocicore.InstanceLifecycleStateTerminated},
+					LifecycleState:     ocicore.InstanceLifecycleStateTerminated,
+					FreeformTags: map[string]string{
+						NodePoolOciFreeFormTagKey: "poolA", NodeClassHashOciFreeFormTagKey: "h"}},
 				{Id: lo.ToPtr("ocid1.instance.oc1..ok"), DisplayName: lo.ToPtr("ok"),
 					AvailabilityDomain: lo.ToPtr("tenancy:PHX-AD-1"),
 					LifecycleState:     ocicore.InstanceLifecycleStateRunning,
@@ -738,44 +1059,17 @@ func TestProvider_Get_List_Delete_WithFakeCompute(t *testing.T) {
 		computeClient:        fc,
 		clusterCompartmentId: "ocid1.compartment.oc1..parent",
 		instanceCache:        cache.NewDefaultGetOrLoadCache[*InstanceInfo](),
-		vnicAttachCache:      cache.NewDefaultGetOrLoadCache[[]*ocicore.VnicAttachment](),
-		bootVolAttachCache:   cache.NewDefaultGetOrLoadCache[[]*ocicore.BootVolumeAttachment](),
 	}
 
 	ctx := context.TODO()
-	// GetInstance
-	info, err := p.GetInstance(ctx, "ocid1.instance.oc1..xyz")
+	insts, err := p.ListInstances(ctx, []string{""})
 	assert.NoError(t, err)
-	assert.Equal(t, "ocid1.instance.oc1..xyz", *info.Id)
-	assert.Equal(t, "etag-1", info.etag)
-	assert.Equal(t, "inst1", *info.DisplayName)
-
-	// List VNIC attachments (cached path covered by calling twice)
-	vas1, err := p.ListInstanceVnicAttachments(ctx, "ocid1.compartment.oc1..c", "ocid1.instance.oc1..xyz")
+	assert.Len(t, insts, 1)
+	getCountAfterList := fc.GetCount.Get()
+	listedInfo, err := p.GetInstanceCached(ctx, "ocid1.instance.oc1..ok")
 	assert.NoError(t, err)
-	assert.Len(t, vas1, 1)
-
-	// Cached wrapper uses cache; to exercise wrapper without reflection, call twice and ensure same result length
-	// ensure calling direct and then cached path is separate
-	p.vnicAttachCache = cache.NewDefaultGetOrLoadCache[[]*ocicore.VnicAttachment]()
-	vas2, err := p.ListInstanceVnicAttachments(ctx, "ocid1.compartment.oc1..c", "ocid1.instance.oc1..xyz")
-	assert.NoError(t, err)
-	assert.Equal(t, len(vas1), len(vas2))
-
-	// List Boot Volume Attachments
-	bvas, err := p.ListInstanceBootVolumeAttachments(ctx, "ocid1.compartment.oc1..c",
-		"ocid1.instance.oc1..xyz", "tenancy:PHX-AD-1")
-	assert.NoError(t, err)
-	assert.Len(t, bvas, 1)
-
-	// ListInstances filters terminated and missing tag
-	insts, err := p.ListInstances(ctx, "") // "" -> default compartment
-	assert.NoError(t, err)
-	assert.Len(t, insts, 1) // only "ok" instance remains
-
-	// DeleteInstance (Terminate)
-	err = p.DeleteInstance(ctx, "ocid1.instance.oc1..xyz")
-	assert.NoError(t, err)
+	assert.Equal(t, "ocid1.instance.oc1..ok", *listedInfo.Id)
+	assert.Equal(t, getCountAfterList, fc.GetCount.Get(), "ListInstances should write through")
 }
 
 func TestProvider_LaunchInstance_RequestConstruction(t *testing.T) {
@@ -1067,35 +1361,6 @@ func TestProvider_ListAttachments_Pagination(t *testing.T) {
 		"ocid1.instance.oc1..id", "tenancy:PHX-AD-1")
 	require.NoError(t, err)
 	require.Len(t, bvas, 2)
-}
-
-func TestProvider_ErrorPaths_Get_ListInstances(t *testing.T) {
-	// GetInstance error
-	fc := &fakes.FakeCompute{
-		GetErr: errors.New("get instance error"),
-	}
-	p := &DefaultProvider{
-		computeClient:        fc,
-		clusterCompartmentId: "ocid1.compartment.oc1..parent",
-		instanceCache:        cache.NewDefaultGetOrLoadCache[*InstanceInfo](),
-		vnicAttachCache:      cache.NewDefaultGetOrLoadCache[[]*ocicore.VnicAttachment](),
-		bootVolAttachCache:   cache.NewDefaultGetOrLoadCache[[]*ocicore.BootVolumeAttachment](),
-		launchTimeoutVM:      10 * time.Minute,
-		launchTimeoutBM:      20 * time.Minute,
-	}
-	_, err := p.GetInstance(context.TODO(), "ocid1.instance.oc1..x")
-	require.Error(t, err)
-
-	// ListInstances error
-	fc2 := &fakes.FakeCompute{
-		ListInstancesErr: errors.New("list instances error"),
-	}
-	p2 := &DefaultProvider{
-		computeClient:        fc2,
-		clusterCompartmentId: "ocid1.compartment.oc1..parent",
-	}
-	_, err = p2.ListInstances(context.TODO(), "")
-	require.Error(t, err)
 }
 
 func TestProvider_DecorateNodeClaimByInstance_EdgeCases(t *testing.T) {
@@ -1603,6 +1868,7 @@ func TestProvider_LaunchInstance_WorkRequestSuccess(t *testing.T) {
 		launchTimeoutVM:      10 * time.Minute,
 		launchTimeoutBM:      20 * time.Minute,
 		pollInterval:         time.Second,
+		instanceCache:        cache.NewNonExpiringGetOrLoadCache[*InstanceInfo](),
 	}
 
 	it := &instancetype.OciInstanceType{
@@ -1621,6 +1887,10 @@ func TestProvider_LaunchInstance_WorkRequestSuccess(t *testing.T) {
 	assert.NotNil(t, inst)
 	assert.Equal(t, "ocid1.instance.oc1..new", *inst.Id)
 	assert.Greater(t, callCount, 0, "expected GetWorkRequest called at least once")
+	cached, err := p.GetInstanceCached(context.TODO(), "ocid1.instance.oc1..new")
+	require.NoError(t, err)
+	assert.Same(t, inst, cached)
+	assert.Equal(t, 0, fc.GetCount.Get(), "successful launch should seed the instance cache")
 }
 
 func TestProvider_LaunchInstance_WorkRequestOutOfHostCapacity(t *testing.T) {
@@ -1823,6 +2093,9 @@ func TestProvider_LaunchInstance_Timeout(t *testing.T) {
 		require.NoError(t, launchErr)
 		assert.NotNil(t, inst)
 		assert.Equal(t, instanceId1, *inst.Id)
+		cached, cacheErr := p.GetInstanceCached(context.TODO(), instanceId1)
+		require.NoError(t, cacheErr)
+		assert.Same(t, inst, cached)
 	})
 
 	t.Run("launch a vm shape timeout, then retrieve volumes success with attached volume,"+

--- a/pkg/providers/network/provider.go
+++ b/pkg/providers/network/provider.go
@@ -36,6 +36,7 @@ var (
 
 	InvalidSubnetConfigError = errors.New("define either ocid or subnet selector")
 	InvalidNsgConfigError    = errors.New("define either networkSecurityGroup ids or networkSecurityGroup selectors")
+	errVnicCacheRequired     = errors.New("VNIC cache is required")
 
 	AdSubnetError                      = errors.New("ad local subnet is not supported")
 	NoSecondaryVnicConfigError         = errors.New("no secondaryVnicConfigs found")
@@ -65,7 +66,11 @@ type DefaultProvider struct {
 }
 
 func NewProvider(ctx context.Context, clusterVcnCompartmentId string, npnCluster bool,
-	ipFamilies []IpFamily, vcnClient oci.VirtualNetworkClient) (*DefaultProvider, error) {
+	ipFamilies []IpFamily, vcnClient oci.VirtualNetworkClient,
+	vnicCache *cache.GetOrLoadCache[*ocicore.Vnic]) (*DefaultProvider, error) {
+	if vnicCache == nil {
+		return nil, errVnicCacheRequired
+	}
 	p := &DefaultProvider{
 		clusterVcnCompartmentId: clusterVcnCompartmentId,
 		npnCluster:              npnCluster,
@@ -77,7 +82,7 @@ func NewProvider(ctx context.Context, clusterVcnCompartmentId string, npnCluster
 
 		nsgCache:         cache.NewDefaultGetOrLoadCache[*ocicore.NetworkSecurityGroup](),
 		nsgSelectorCache: cache.NewDefaultGetOrLoadCache[[]*ocicore.NetworkSecurityGroup](),
-		vnicCache:        cache.NewDefaultGetOrLoadCache[*ocicore.Vnic](),
+		vnicCache:        vnicCache,
 	}
 
 	return p, nil
@@ -500,8 +505,10 @@ func (p *DefaultProvider) listAndFilterNsgs(ctx context.Context, req ocicore.Lis
 }
 
 func (p *DefaultProvider) GetVnic(ctx context.Context, vnicOcid string) (*ocicore.Vnic, error) {
-	p.vnicCache.Evict(ctx, vnicOcid)
-	return p.GetVnicCached(ctx, vnicOcid)
+	return p.vnicCache.Refresh(ctx, vnicOcid,
+		func(ctx context.Context, _ string) (*ocicore.Vnic, error) {
+			return p.getVnicImpl(ctx, vnicOcid)
+		})
 }
 
 func (p *DefaultProvider) getVnicImpl(ctx context.Context, vnicOcid string) (*ocicore.Vnic, error) {
@@ -517,9 +524,10 @@ func (p *DefaultProvider) getVnicImpl(ctx context.Context, vnicOcid string) (*oc
 }
 
 func (p *DefaultProvider) GetVnicCached(ctx context.Context, vnicOcid string) (*ocicore.Vnic, error) {
-	return p.vnicCache.GetOrLoad(ctx, vnicOcid, func(ctx context.Context, key string) (*ocicore.Vnic, error) {
-		return p.getVnicImpl(ctx, key)
-	})
+	return p.vnicCache.GetOrLoad(ctx, vnicOcid,
+		func(ctx context.Context, _ string) (*ocicore.Vnic, error) {
+			return p.getVnicImpl(ctx, vnicOcid)
+		})
 }
 
 func strPtrToStr(strValue *string) string {

--- a/pkg/providers/network/provider_test.go
+++ b/pkg/providers/network/provider_test.go
@@ -9,9 +9,11 @@ package network
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
+	"github.com/oracle/karpenter-provider-oci/pkg/cache"
 	"github.com/oracle/karpenter-provider-oci/pkg/fakes"
 	ocicore "github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/samber/lo"
@@ -26,7 +28,7 @@ func setupTest(t *testing.T) func(t *testing.T) {
 	vcnClient := fakes.FakeVirtualNetwork{}
 	var err error
 	provider, err = NewProvider(context.TODO(), "testVcnCompartmentId", true,
-		[]IpFamily{IPv4}, &vcnClient)
+		[]IpFamily{IPv4}, &vcnClient, newTestVnicCache())
 	if err != nil {
 		t.Fatalf("could not create DefaultProvider")
 	}
@@ -44,6 +46,52 @@ func TestResolveSimpleVnicConfigWithNoError(t *testing.T) {
 
 	_, err := provider.resolveSimpleVnicConfig(context.TODO(), testConfig, "testIdentifier")
 	assert.NoError(t, err)
+}
+
+func TestVnicFreshReadWritesThroughAndFailurePreservesCache(t *testing.T) {
+	ctx := context.Background()
+	current := &ocicore.Vnic{Id: lo.ToPtr("vnic-1"), DisplayName: lo.ToPtr("old")}
+	var freshErr error
+	vcnClient := &fakes.FakeVirtualNetwork{
+		OnGetVnic: func(context.Context, ocicore.GetVnicRequest) (ocicore.GetVnicResponse, error) {
+			if freshErr != nil {
+				return ocicore.GetVnicResponse{}, freshErr
+			}
+			return ocicore.GetVnicResponse{Vnic: *current}, nil
+		},
+	}
+	p, err := NewProvider(ctx, "compartment-1", false, []IpFamily{IPv4}, vcnClient, newTestVnicCache())
+	assert.NoError(t, err)
+
+	cached, err := p.GetVnicCached(ctx, "vnic-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "old", *cached.DisplayName)
+	assert.Equal(t, 1, vcnClient.GetVnicCount)
+
+	current = &ocicore.Vnic{Id: lo.ToPtr("vnic-1"), DisplayName: lo.ToPtr("new")}
+	cachedAgain, err := p.GetVnicCached(ctx, "vnic-1")
+	assert.NoError(t, err)
+	assert.Same(t, cached, cachedAgain)
+	assert.Equal(t, "old", *cachedAgain.DisplayName)
+	assert.Equal(t, 1, vcnClient.GetVnicCount)
+
+	refreshed, err := p.GetVnic(ctx, "vnic-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "new", *refreshed.DisplayName)
+	assert.Equal(t, 2, vcnClient.GetVnicCount)
+	cached, err = p.GetVnicCached(ctx, "vnic-1")
+	assert.NoError(t, err)
+	assert.Same(t, refreshed, cached)
+	assert.Equal(t, 2, vcnClient.GetVnicCount)
+
+	freshErr = errors.New("temporary VNIC read failure")
+	_, err = p.GetVnic(ctx, "vnic-1")
+	assert.Error(t, err)
+	assert.Equal(t, 3, vcnClient.GetVnicCount)
+	cached, err = p.GetVnicCached(ctx, "vnic-1")
+	assert.NoError(t, err)
+	assert.Same(t, refreshed, cached)
+	assert.Equal(t, 3, vcnClient.GetVnicCount)
 }
 
 func TestResolveSimpleVnicConfigWithDifferentSubnet(t *testing.T) {
@@ -162,7 +210,7 @@ func TestResolveNetworkConfig_NPNCluster_NoSecondaryVnics(t *testing.T) {
 	// Create NPN cluster provider
 	vcnClient := fakes.FakeVirtualNetwork{}
 	npnProvider, err := NewProvider(context.TODO(), "testVcnCompartmentId", true,
-		[]IpFamily{IPv4}, &vcnClient)
+		[]IpFamily{IPv4}, &vcnClient, newTestVnicCache())
 	assert.NoError(t, err)
 
 	networkCfg := &v1beta1.NetworkConfig{
@@ -185,7 +233,7 @@ func TestResolveNetworkConfig_NonNPNCluster_WithSecondaryVnics(t *testing.T) {
 	// Create non-NPN cluster provider
 	vcnClient := fakes.FakeVirtualNetwork{}
 	nonNpnProvider, err := NewProvider(context.TODO(), "testVcnCompartmentId", false,
-		[]IpFamily{IPv4}, &vcnClient)
+		[]IpFamily{IPv4}, &vcnClient, newTestVnicCache())
 	assert.NoError(t, err)
 
 	networkCfg := &v1beta1.NetworkConfig{
@@ -252,24 +300,6 @@ func TestResolveNsgs_InvalidConfig(t *testing.T) {
 	_, err := provider.resolveNsgs(context.TODO(), configs)
 	assert.Error(t, err)
 	assert.Equal(t, InvalidNsgConfigError, err)
-}
-
-func TestGetVnic(t *testing.T) {
-	teardownTest := setupTest(t)
-	defer teardownTest(t)
-
-	_, err := provider.GetVnic(context.TODO(), "testVnicId")
-	// Fake client returns empty response, should not error
-	assert.NoError(t, err)
-}
-
-func TestGetVnicCached(t *testing.T) {
-	teardownTest := setupTest(t)
-	defer teardownTest(t)
-
-	_, err := provider.GetVnicCached(context.TODO(), "testVnicId")
-	// Fake client returns empty response, should not error
-	assert.NoError(t, err)
 }
 
 func TestFilterSubnets_ByDisplayName_Cache(t *testing.T) {
@@ -409,24 +439,19 @@ func TestIsFromDifferentVcn_SameId(t *testing.T) {
 	assert.False(t, provider.isFromDifferentVcn(nsg, subnet))
 }
 
-func TestGetVnicCached_CacheHit(t *testing.T) {
-	provider, fake := newProviderForNetworkTests([]IpFamily{IPv4}, false)
-
-	// First call
-	_, err := provider.GetVnicCached(context.TODO(), "vnic-1")
-	assert.NoError(t, err)
-	assert.Equal(t, 1, fake.GetVnicCount)
-
-	// Second call - should be from cache
-	_, err = provider.GetVnicCached(context.TODO(), "vnic-1")
-	assert.NoError(t, err)
-	assert.Equal(t, 1, fake.GetVnicCount) // unchanged = cache hit
-}
-
 func newProviderForNetworkTests(ipFamilies []IpFamily, npnCluster bool) (*DefaultProvider, *fakes.FakeVirtualNetwork) {
 	vcn := fakes.NewFakeVcnForNetworkTests()
-	p, _ := NewProvider(context.TODO(), "vcn-1", npnCluster, ipFamilies, vcn)
+	p, _ := NewProvider(context.TODO(), "vcn-1", npnCluster, ipFamilies, vcn, newTestVnicCache())
 	return p, vcn
+}
+
+func newTestVnicCache() *cache.GetOrLoadCache[*ocicore.Vnic] {
+	return cache.NewNonExpiringGetOrLoadCache[*ocicore.Vnic]()
+}
+
+func TestNewProviderRequiresVnicCache(t *testing.T) {
+	_, err := NewProvider(context.Background(), "", false, nil, nil, nil)
+	assert.ErrorIs(t, err, errVnicCacheRequired)
 }
 
 func TestFilterNsg_ByDisplayName_Cache(t *testing.T) {


### PR DESCRIPTION
# Description

This change replaces time-based expiration for instance drift resources with non-expiring, write-through caches. It reduces OCI API calls in large clusters by avoiding cache-expiration fan-out across nodes.

Instance, VNIC attachment, VNIC, boot-volume attachment, and boot-volume data are cached after successful OCI reads. Fresh-read failures preserve the existing cached value. Cache entries are removed when an instance is terminated, returns NotFound, is deleted, or is removed during list-based garbage collection.

External VNIC or boot-volume changes made directly in OCI may not be detected while the cached state continues to match the desired configuration.

No new dependencies are introduced.

Fixes: N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

The following validation was completed:

- [x] `go test -mod=readonly ./cmd/... ./pkg/...`
- [x] `go vet -mod=readonly ./...`
- [x] `golangci-lint run --modules-download-mode=readonly`
- [x] `git diff --check`

- Kubernetes version: N/A (unit tests only)
- OKE version: N/A (unit tests only)
- Karpenter Provider OCI version: `cache-refactoring` (`fd5949b`)
- Installation method (`helm`, manifests, local run): Local test run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (not applicable; no downstream dependencies)