### PR TITLE
Fix NodeClaim typo and tighten taint warning messages

### DIFF
--- a/pkg/providers/instancetype/provider.go
+++ b/pkg/providers/instancetype/provider.go
@@ -905,12 +905,12 @@ func CheckTaintsAndPrintWarnings(ctx context.Context, nodeClaim *corev1.NodeClai
 
 	if !checkTaintExists(nodeClaim.Spec.Taints, NvidiaGpuTaintKey) &&
 		!checkTaintExists(nodeClaim.Spec.Taints, AmdGpuTaintKey) {
-		lg.Info(fmt.Sprintf("NodeCalim doesn't have taints '%s' or '%s' will not offer GPU shapes",
+		lg.Info(fmt.Sprintf("NodeClaim missing taint '%s' or '%s'; not offering GPU shapes",
 			NvidiaGpuTaintKey, AmdGpuTaintKey))
 	}
 
 	if !checkTaintExists(nodeClaim.Spec.Taints, PreemptibleTaintKey) {
-		lg.Info(fmt.Sprintf("NodeCalim doesn't have taint '%s' will not offer preemptible shape",
+		lg.Info(fmt.Sprintf("NodeClaim missing taint '%s'; not offering preemptible shapes",
 			PreemptibleTaintKey))
 	}
 }


### PR DESCRIPTION
Fixes the "NodeCalim" typo in `CheckTaintsAndPrintWarnings` and tightens both messages:

```
NodeClaim missing taint '%s' or '%s'; not offering GPU shapes
NodeClaim missing taint '%s'; not offering preemptible shapes
```

Log-message-only change; no behavior.