### PR TITLE
Include KPO version in OCI user agent

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
             - name: HEALTH_PROBE_PORT
               value: "{{ .Values.controller.healthProbe.port }}"
             - name: OCI_SDK_APPEND_USER_AGENT
-              value: 'karpenter-provider-oci/{{ trimPrefix "v" .Chart.AppVersion }}'
+              value: 'karpenter-provider-oci/{{ .Chart.Version }}'
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
             - name: HEALTH_PROBE_PORT
               value: "{{ .Values.controller.healthProbe.port }}"
             - name: OCI_SDK_APPEND_USER_AGENT
-              value: "karpenter-provider-oci"
+              value: 'karpenter-provider-oci/{{ trimPrefix "v" .Chart.AppVersion }}'
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
# Summary

Include the Karpenter Provider OCI version in the User-Agent appended to outgoing OCI SDK requests.

The version is derived directly from `.Chart.Version`.

Example:

```text
karpenter-provider-oci/1.3.0
```

This improves request attribution and makes it possible to distinguish OCI API traffic generated by different KPO versions.

# Changes

- Updated `OCI_SDK_APPEND_USER_AGENT` in the controller Deployment template.
- Used `.Chart.Version` as the KPO version.
- Appended the version using the standard `product/version` User-Agent format.

# Testing

- Ran `helm lint chart`.
- Rendered the Helm chart and verified:

```yaml
- name: OCI_SDK_APPEND_USER_AGENT
  value: 'karpenter-provider-oci/1.3.0'
```