### PR TITLE
fix: model OCI VM memory overhead in instance type capacity

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -172,6 +172,20 @@ spec:
             - name: ENABLE_UNAVAILABLE_OFFERINGS_ON_SERVICE_LIMIT_EXCEEDED
               value: "{{ .Values.settings.enableUnavailableOfferingsOnServiceLimitExceeded }}"
             {{- end }}
+            {{- with .Values.settings.vmMemoryOverhead }}
+            {{- if not (kindIs "invalid" .baseMiB) }}
+            - name: VM_MEMORY_OVERHEAD_BASE_MIB
+              value: "{{ .baseMiB }}"
+            {{- end }}
+            {{- if not (kindIs "invalid" .perGBMiB) }}
+            - name: VM_MEMORY_OVERHEAD_PER_GB_MIB
+              value: "{{ .perGBMiB }}"
+            {{- end }}
+            {{- if not (kindIs "invalid" .percent) }}
+            - name: VM_MEMORY_OVERHEAD_PERCENT
+              value: "{{ .percent }}"
+            {{- end }}
+            {{- end }}
             {{- with .Values.settings.flexibleShapeConfigs }}
             - name: FLEXIBLE_SHAPE_CONFIGS
               value: {{ . | toJson | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -278,6 +278,32 @@ settings:
   # -- When true, OCI LimitExceeded and QuotaExceeded failures mark the offering unavailable. Disabled by default.
   enableUnavailableOfferingsOnServiceLimitExceeded: false
 
+  # VM memory overhead. OCI reserves memory below the guest, so a VM shape advertised as 32 GB
+  # presents roughly 30.9 GiB of MemTotal to Linux. Karpenter must estimate a node's memory
+  # before the node exists, so this is subtracted from every VM shape's modelled capacity.
+  #
+  # Bare metal (BM.*) shapes are exempt: the overhead is a hypervisor artefact and there is no
+  # hypervisor beneath a BM instance, so they keep their declared memory.
+  #
+  # These defaults are deliberately pessimistic, because the two failure modes are not
+  # symmetric: over-estimating capacity makes Karpenter launch a node the pending pod cannot
+  # fit on, and with no feedback loop it repeats that launch indefinitely. Under-estimating
+  # only wastes a little memory. The goal is a safe number, not an exact one.
+  #
+  # Defaults are a lower bound on measured capacity across every published measurement
+  # (A1/E4/E5/Standard3, 8-128 GB) -- see issue #7 -- with deliberate headroom on top, so that
+  # an image build or shape family nobody has measured is unlikely to breach them. Tighten them
+  # only if you have measured `node.status.capacity.memory` for your own shapes and images.
+  vmMemoryOverhead:
+    # -- Fixed part of the overhead, in MiB.
+    baseMiB: 600
+    # -- Part of the overhead that scales with declared memory, in MiB per GiB.
+    perGBMiB: 19
+    # -- An alternative way of expressing the overhead, as a fraction of declared memory
+    # (0.075 == 7.5%). 0 means unused. The larger of the two forms is applied, so setting this
+    # can only make the estimate more conservative, never less.
+    percent: 0
+
   # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
   # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features
   featureGates:

--- a/docs/guide/faqs.md
+++ b/docs/guide/faqs.md
@@ -300,3 +300,30 @@ If you want to run OCI GO SDK in debug mode (Karpenter uses OCI GO SDK to intera
 
 ### Suggestions regarding KubeletConfig maxPods and podsPerCore
 The value assigned to "podsPerCore" must not exceed the "maxPods" value. Additionally, for environments in which the customer is utilizing an OciVcnIpNative cluster, the "maxPods" value should be less than the aggregate sum of "IpCount" from the secondary VNICs.
+
+### How does KPO account for OCI VM memory overhead?
+OCI reserves memory below the guest, so a VM shape advertised as 32 GB presents roughly 30.9 GiB of `MemTotal` to Linux. Karpenter has to size a node *before* it exists, so it works from a model rather than a measurement. If that model used the advertised figure it would over-state what the node can hold, the pod that triggered the launch would not fit once the node registered, and — because nothing compares the model against the node it produced — the same launch would repeat.
+
+The provider therefore subtracts a memory overhead from each VM shape's modelled capacity:
+
+```
+overheadMiB = max(baseMiB + perGBMiB × declaredGiB, percent × declaredMiB)
+```
+
+Defaults are `600` MiB plus `19` MiB per GiB, which on a 32 GB shape reserves about 1.2 GiB. They are deliberately pessimistic: over-stating capacity causes repeated launches of nodes a pod can never fit on, while under-stating it only leaves a little memory unused.
+
+**Bare metal (`BM.*`) shapes are exempt** and keep their declared memory, since the overhead models a hypervisor and there is none beneath a BM instance.
+
+To tune it, set any of the following under `settings.vmMemoryOverhead` in the Helm values (or the equivalent `VM_MEMORY_OVERHEAD_BASE_MIB`, `VM_MEMORY_OVERHEAD_PER_GB_MIB`, `VM_MEMORY_OVERHEAD_PERCENT` environment variables):
+
+```yaml
+settings:
+  vmMemoryOverhead:
+    baseMiB: 600
+    perGBMiB: 19
+    percent: 0
+```
+
+`percent` is an alternative way of expressing the overhead, as a fraction of declared memory (`0.075` == 7.5%). It defaults to `0`, meaning unused. Because the two forms are combined with `max()`, setting it can only ever make the estimate more conservative, never less. Setting all three to `0` disables the adjustment entirely and restores the advertised figure.
+
+Tighten these only if you have measured `node.status.capacity.memory` on the shapes and images you actually run: a value that leaves Karpenter over-stating a node's memory brings back the repeated-launch behaviour described above.

--- a/docs/reference/helm-chart.md
+++ b/docs/reference/helm-chart.md
@@ -91,6 +91,9 @@ A Helm chart for Karpenter provider OCI
 | settings.rateLimiter.qpsWrite | float | `0` | Write QPS for the OCI client-side rate limiter. 0 uses the built-in default. |
 | settings.unavailableOfferingsTTLSeconds | int | `180` | How long, in seconds, an offering observed to be out of host capacity is treated as unavailable before Karpenter retries it. Lower values retry exhausted offerings sooner; higher values reduce repeated launch attempts (and OCI throttling) against capacity that is unlikely to recover quickly. Set to 0 to disable the unavailable-offerings cache entirely, in which case offerings are never marked unavailable and Karpenter does not route around capacity-exhausted offerings. |
 | settings.vcnCompartmentId | string | `""` | [required] Cluster's VCN compartment OCID. |
+| settings.vmMemoryOverhead.baseMiB | int | `600` | Fixed part of the overhead, in MiB. |
+| settings.vmMemoryOverhead.perGBMiB | int | `19` | Part of the overhead that scales with declared memory, in MiB per GiB. |
+| settings.vmMemoryOverhead.percent | int | `0` | An alternative way of expressing the overhead, as a fraction of declared memory (0.075 == 7.5%). 0 means unused. The larger of the two forms is applied, so setting this can only make the estimate more conservative, never less. |
 | strategy | object | `{"rollingUpdate":{"maxUnavailable":1}}` | Strategy for updating the pod. |
 | terminationGracePeriodSeconds | string | `nil` | Override the default termination grace period for the pod. |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"}]` | Tolerations to allow the pod to be scheduled to nodes with taints. |

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -139,6 +139,7 @@ func createOperator(ctx context.Context, coreOp *operator.Operator,
 		shapeMetaFile, refreshInterval, ociOptions.GlobalShapeConfigs,
 		ociOptions.IpFamiliesFlag.IpFamilies,
 		unavailableOfferings,
+		ociOptions.VMMemoryOverhead(),
 		coreOp.Elected()))
 
 	driftCaches := instance.NewDriftCaches()

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -14,11 +14,13 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strings"
 
 	ociv1beta1 "github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
 	"github.com/oracle/karpenter-provider-oci/pkg/cache"
+	"github.com/oracle/karpenter-provider-oci/pkg/providers/instancetype"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/network"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -49,6 +51,9 @@ type Options struct {
 	RateLimitBurstRead                               int
 	RateLimitQPSWrite                                float64
 	RateLimitBurstWrite                              int
+	VMMemoryOverheadBaseMiB                          float64
+	VMMemoryOverheadPerGBMiB                         float64
+	VMMemoryOverheadPercent                          float64
 	setFlags                                         map[string]bool
 	parsed                                           bool
 }
@@ -137,6 +142,26 @@ Example in a JSON format:
 		"Write QPS for the OCI client-side rate limiter. 0 uses the default")
 	fs.IntVar(&o.RateLimitBurstWrite, "rate-limit-burst-write", 0,
 		"Write burst for the OCI client-side rate limiter. 0 uses the default")
+
+	// VM memory overhead: OCI reserves memory below the guest, so a VM shape declared as N GB
+	// presents less than N GiB of MemTotal to Linux. Bare metal has no hypervisor beneath it and
+	// is exempt. Karpenter must model this before the node
+	// exists, otherwise it launches nodes the pending pod cannot fit on and retries forever.
+	// The defaults are deliberately pessimistic: over-estimating capacity causes an unbounded
+	// launch loop, while under-estimating only wastes a little memory.
+	fs.Float64Var(&o.VMMemoryOverheadBaseMiB, "vm-memory-overhead-base-mib",
+		instancetype.DefaultVMMemoryOverheadBaseMiB,
+		"Fixed part, in MiB, of the memory overhead subtracted from every VM shape's modelled "+
+			"capacity. Bare metal shapes are exempt")
+	fs.Float64Var(&o.VMMemoryOverheadPerGBMiB, "vm-memory-overhead-per-gb-mib",
+		instancetype.DefaultVMMemoryOverheadPerGBMiB,
+		"Proportional part, in MiB per GiB of declared memory, of the memory overhead "+
+			"subtracted from every VM shape's modelled capacity. Bare metal shapes are exempt")
+	fs.Float64Var(&o.VMMemoryOverheadPercent, "vm-memory-overhead-percent",
+		instancetype.DefaultVMMemoryOverheadPercent,
+		"Memory overhead as a fraction of declared memory (0.075 equals 7.5%). Applied as "+
+			"max(base + perGB*GiB, percent*declared) so the larger, safer estimate always wins. "+
+			"0 disables the percentage form")
 
 	fs.Var((*RepairPoliciesValue)(&o.RepairPolicies),
 		"repair-policies",
@@ -242,7 +267,34 @@ func (o *Options) Validate() error {
 		return errors.New("rate-limit-burst-write must be greater than or equal to 0")
 	}
 
+	if !isFiniteInRange(o.VMMemoryOverheadBaseMiB, 0, math.MaxInt32) {
+		return errors.New("vm-memory-overhead-base-mib must be a finite number in [0, 2147483647]")
+	}
+	if !isFiniteInRange(o.VMMemoryOverheadPerGBMiB, 0, math.MaxInt32) {
+		return errors.New("vm-memory-overhead-per-gb-mib must be a finite number in [0, 2147483647]")
+	}
+	if !isFiniteInRange(o.VMMemoryOverheadPercent, 0, 1) || o.VMMemoryOverheadPercent == 1 {
+		return errors.New("vm-memory-overhead-percent must be a finite number in [0, 1)")
+	}
+
 	return nil
+}
+
+// VMMemoryOverhead assembles the instance type provider's overhead configuration from the parsed
+// flags. It exists so the mapping lives in one testable place: assembled inline at the call site,
+// transposing two same-typed fields would compile and silently model every node wrongly.
+func (o *Options) VMMemoryOverhead() instancetype.VMMemoryOverheadConfig {
+	return instancetype.VMMemoryOverheadConfig{
+		BaseMiB:  o.VMMemoryOverheadBaseMiB,
+		PerGBMiB: o.VMMemoryOverheadPerGBMiB,
+		Percent:  o.VMMemoryOverheadPercent,
+	}
+}
+
+// isFiniteInRange reports whether v is a real number within [lo, hi]. NaN compares false against
+// every bound, so it is rejected by construction rather than needing a separate check.
+func isFiniteInRange(v, lo, hi float64) bool {
+	return v >= lo && v <= hi
 }
 
 func (o *Options) ToContext(ctx context.Context) context.Context {

--- a/pkg/operator/options/options_test.go
+++ b/pkg/operator/options/options_test.go
@@ -10,15 +10,23 @@ package options
 import (
 	"context"
 	"flag"
+	"math"
+	"os"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	ociv1beta1 "github.com/oracle/karpenter-provider-oci/pkg/apis/v1beta1"
+	"github.com/oracle/karpenter-provider-oci/pkg/providers/instancetype"
 	"github.com/oracle/karpenter-provider-oci/pkg/providers/network"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/operator/options"
 )
@@ -345,3 +353,157 @@ var _ = Describe("Test Operator Options", func() {
 		Expect(result).To(Equal(expected))
 	})
 })
+
+// The VM memory overhead defaults are proven safe against real measurements by
+// TestMemoryCapacity_NeverOverEstimates, but only for the constants in pkg/providers/instancetype.
+// These two tests stop the flag defaults and the Helm chart defaults from drifting away from those
+// constants, which would ship an unproven — possibly over-estimating — value.
+
+func TestVMMemoryOverheadDefaults_MatchProviderConstants(t *testing.T) {
+	opts := &Options{IpFamiliesFlag: new(network.IpFamilyValue)}
+	fs := &options.FlagSet{FlagSet: flag.NewFlagSet("test", flag.ContinueOnError)}
+	opts.AddFlags(fs)
+
+	assert.Equal(t, float64(instancetype.DefaultVMMemoryOverheadBaseMiB), opts.VMMemoryOverheadBaseMiB)
+	assert.Equal(t, float64(instancetype.DefaultVMMemoryOverheadPerGBMiB), opts.VMMemoryOverheadPerGBMiB)
+	assert.Equal(t, float64(instancetype.DefaultVMMemoryOverheadPercent), opts.VMMemoryOverheadPercent)
+}
+
+func TestVMMemoryOverheadDefaults_MatchHelmChart(t *testing.T) {
+	raw, err := os.ReadFile("../../../chart/values.yaml")
+	require.NoError(t, err)
+
+	var values struct {
+		Settings struct {
+			VMMemoryOverhead struct {
+				BaseMiB  *float64 `json:"baseMiB"`
+				PerGBMiB *float64 `json:"perGBMiB"`
+				Percent  *float64 `json:"percent"`
+			} `json:"vmMemoryOverhead"`
+		} `json:"settings"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &values))
+
+	chart := values.Settings.VMMemoryOverhead
+	require.NotNil(t, chart.BaseMiB, "chart/values.yaml is missing settings.vmMemoryOverhead.baseMiB")
+	require.NotNil(t, chart.PerGBMiB, "chart/values.yaml is missing settings.vmMemoryOverhead.perGBMiB")
+	require.NotNil(t, chart.Percent, "chart/values.yaml is missing settings.vmMemoryOverhead.percent")
+
+	assert.Equal(t, float64(instancetype.DefaultVMMemoryOverheadBaseMiB), *chart.BaseMiB)
+	assert.Equal(t, float64(instancetype.DefaultVMMemoryOverheadPerGBMiB), *chart.PerGBMiB)
+	assert.Equal(t, float64(instancetype.DefaultVMMemoryOverheadPercent), *chart.Percent)
+}
+
+// The overhead settings are the one place an operator can reintroduce the over-estimation this
+// change exists to prevent, so validation must reject values the arithmetic cannot handle.
+func TestValidateVMMemoryOverhead(t *testing.T) {
+	base := func() *Options {
+		return &Options{
+			ClusterCompartmentId:          "ocid1.compartment.oc1..a",
+			VcnCompartmentId:              "ocid1.compartment.oc1..b",
+			PreBakedImageCompartmentId:    "ocid1.compartment.oc1..c",
+			ApiserverEndpoint:             "10.0.0.1:6443",
+			ShapeMetaRefreshIntervalHours: 24,
+			InstanceLaunchTimeoutVMMins:   5,
+			InstanceLaunchTimeoutBMMins:   60,
+			VMMemoryOverheadBaseMiB:       instancetype.DefaultVMMemoryOverheadBaseMiB,
+			VMMemoryOverheadPerGBMiB:      instancetype.DefaultVMMemoryOverheadPerGBMiB,
+			VMMemoryOverheadPercent:       instancetype.DefaultVMMemoryOverheadPercent,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*Options)
+		wantErr string
+	}{
+		{"shipped defaults are valid", func(*Options) {}, ""},
+		{"percent form is accepted", func(o *Options) { o.VMMemoryOverheadPercent = 0.075 }, ""},
+
+		{"negative base", func(o *Options) { o.VMMemoryOverheadBaseMiB = -1 }, "vm-memory-overhead-base-mib"},
+		{"negative per-gb", func(o *Options) { o.VMMemoryOverheadPerGBMiB = -1 }, "vm-memory-overhead-per-gb-mib"},
+		{"negative percent", func(o *Options) { o.VMMemoryOverheadPercent = -0.1 }, "vm-memory-overhead-percent"},
+
+		// NaN compares false against every bound, so a plain `< 0` check would let it through and
+		// the int64 conversion downstream would be implementation-defined.
+		{"NaN base", func(o *Options) { o.VMMemoryOverheadBaseMiB = math.NaN() }, "vm-memory-overhead-base-mib"},
+		{"NaN per-gb", func(o *Options) { o.VMMemoryOverheadPerGBMiB = math.NaN() }, "vm-memory-overhead-per-gb-mib"},
+		{"NaN percent", func(o *Options) { o.VMMemoryOverheadPercent = math.NaN() }, "vm-memory-overhead-percent"},
+
+		{"infinite base", func(o *Options) { o.VMMemoryOverheadBaseMiB = math.Inf(1) }, "vm-memory-overhead-base-mib"},
+		{"infinite per-gb", func(o *Options) { o.VMMemoryOverheadPerGBMiB = math.Inf(1) }, "vm-memory-overhead-per-gb-mib"},
+
+		// 100% would model every node as having no memory at all.
+		{"percent of one", func(o *Options) { o.VMMemoryOverheadPercent = 1 }, "vm-memory-overhead-percent"},
+		{"percent above one", func(o *Options) { o.VMMemoryOverheadPercent = 2 }, "vm-memory-overhead-percent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := base()
+			tt.mutate(o)
+
+			err := o.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+// Guards the mapping from flags to the provider's config. Transposing two same-typed fields here
+// would compile and silently model every node's memory wrongly.
+func TestOptions_VMMemoryOverhead(t *testing.T) {
+	o := &Options{
+		VMMemoryOverheadBaseMiB:  601,
+		VMMemoryOverheadPerGBMiB: 17,
+		VMMemoryOverheadPercent:  0.075,
+	}
+
+	// Distinct values, so a transposition cannot pass.
+	assert.Equal(t, instancetype.VMMemoryOverheadConfig{
+		BaseMiB:  601,
+		PerGBMiB: 17,
+		Percent:  0.075,
+	}, o.VMMemoryOverhead())
+}
+
+// The chart reaches the provider through environment variables whose names KPO derives from the
+// flag names. A typo on either side is silent: the flag keeps its built-in default and the chart
+// value is ignored. Assert the deployment template carries exactly the names the flags imply.
+func TestVMMemoryOverheadEnvVarsMatchFlagNames(t *testing.T) {
+	opts := &Options{IpFamiliesFlag: new(network.IpFamilyValue)}
+	fs := &options.FlagSet{FlagSet: flag.NewFlagSet("test", flag.ContinueOnError)}
+	opts.AddFlags(fs)
+
+	raw, err := os.ReadFile("../../../chart/templates/deployment.yaml")
+	require.NoError(t, err)
+	deployment := string(raw)
+
+	for _, flagName := range []string{
+		"vm-memory-overhead-base-mib",
+		"vm-memory-overhead-per-gb-mib",
+		"vm-memory-overhead-percent",
+	} {
+		require.NotNil(t, fs.Lookup(flagName), "flag %s must exist", flagName)
+
+		// Parse() derives the env name from the flag name this way.
+		envName := strings.ReplaceAll(strings.ToUpper(flagName), "-", "_")
+		// Match the whole line: a bare substring check would also accept a suffixed typo such as
+		// VM_MEMORY_OVERHEAD_BASE_MIB_TYPO, which is exactly the mistake this guards against.
+		assert.Regexp(t, regexp.MustCompile(`(?m)^\s*- name: `+regexp.QuoteMeta(envName)+`\s*$`), deployment,
+			"chart/templates/deployment.yaml must set %s exactly, or the chart value is silently ignored", envName)
+	}
+
+	// Go templates treat 0 as falsy, so guarding a numeric field with `with` would silently drop
+	// an explicitly configured zero and fall back to the built-in default - a live bug in the AWS
+	// and Azure charts. Guarding the enclosing map with `with` is fine; a non-empty map is truthy.
+	for _, field := range []string{".baseMiB", ".perGBMiB", ".percent"} {
+		assert.Contains(t, deployment, `if not (kindIs "invalid" `+field+")",
+			"%s must be guarded by kindIs \"invalid\" so an explicit 0 is not discarded", field)
+		assert.NotContains(t, deployment, "with "+field+" }}",
+			"%s must not be guarded by `with`: Go templates treat 0 as falsy", field)
+	}
+}

--- a/pkg/providers/instancetype/provider.go
+++ b/pkg/providers/instancetype/provider.go
@@ -85,6 +85,7 @@ type DefaultProvider struct {
 	k8sVersion                    *semver.Version
 	ipFamilies                    []network.IpFamily
 	unavailableOfferings          *cache.UnavailableOfferings
+	vmMemoryOverhead              VMMemoryOverheadConfig
 
 	lock sync.RWMutex
 }
@@ -104,6 +105,7 @@ func New(ctx context.Context,
 	globalShapeConfigs []ociv1beta1.ShapeConfig,
 	ipFamilies []network.IpFamily,
 	unavailableOfferings *cache.UnavailableOfferings,
+	vmMemoryOverhead VMMemoryOverheadConfig,
 	startAsync <-chan struct{}) (*DefaultProvider, error) {
 	p := &DefaultProvider{
 		region:                        region,
@@ -120,6 +122,7 @@ func New(ctx context.Context,
 		ipFamilies:                    ipFamilies,
 		kubernetesInterface:           kubernetesInterface,
 		unavailableOfferings:          unavailableOfferings,
+		vmMemoryOverhead:              vmMemoryOverhead,
 	}
 
 	p.GlobalShapeConfigs = lo.Map(globalShapeConfigs, func(item ociv1beta1.ShapeConfig, _ int) *ociv1beta1.ShapeConfig {
@@ -312,7 +315,7 @@ func (p *DefaultProvider) decorateInstanceType(ctx context.Context, it *OciInsta
 	}
 
 	// Set capacity & overhead
-	setCapacity(it, shape, ocpu, memoryInGbs, nodeClass, p.ipFamilies)
+	setCapacity(it, shape, ocpu, memoryInGbs, nodeClass, p.ipFamilies, p.vmMemoryOverhead)
 	setOverhead(it, shape, ocpu, memoryInGbs, nodeClass)
 
 	basePrice, priceAvailable := p.calculatePrices(shape, ocpu, memoryInGbs, cpuBaseline)
@@ -468,12 +471,13 @@ func makeRequirement(ad string, capType string) scheduling.Requirements {
 }
 
 func setCapacity(it *OciInstanceType, shape *ocicore.Shape, ocpu float32, gbs float32,
-	class *ociv1beta1.OCINodeClass, ipFamilies []network.IpFamily) {
+	class *ociv1beta1.OCINodeClass, ipFamilies []network.IpFamily,
+	vmMemoryOverhead VMMemoryOverheadConfig) {
 	vcpu := vcpu(shape, ocpu)
 
 	res := v1.ResourceList{
 		v1.ResourceCPU:    *resource.NewMilliQuantity(int64(vcpu*1000), resource.DecimalSI),
-		v1.ResourceMemory: *resource.NewQuantity(int64(gbs*1024*1024*1024), resource.BinarySI),
+		v1.ResourceMemory: *resource.NewQuantity(memoryCapacityMiB(shape, gbs, vmMemoryOverhead)*1024*1024, resource.BinarySI),
 		v1.ResourcePods:   *pods(int64(vcpu), class, ipFamilies),
 	}
 

--- a/pkg/providers/instancetype/provider_test.go
+++ b/pkg/providers/instancetype/provider_test.go
@@ -391,7 +391,7 @@ func TestSetCapacity_GPUResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			it := &OciInstanceType{}
 
-			setCapacity(it, &tt.shape, 2, 8, nc, ipV4SingleStack)
+			setCapacity(it, &tt.shape, 2, 8, nc, ipV4SingleStack, defaultVMMemoryOverhead)
 
 			assert.Contains(t, it.Capacity, v1.ResourceCPU)
 			assert.Contains(t, it.Capacity, v1.ResourceMemory)
@@ -2019,7 +2019,7 @@ func TestKubeReservedResources(t *testing.T) {
 			mem:   8,
 			nc:    &ociv1beta1.OCINodeClass{},
 			want: map[string]string{
-				"cpu":    "85m",
+				"cpu": "85m",
 				// 8 GiB shape -> 0.20*(8-4)+1 = 1.8 GiB reserved, in bytes (float32)
 				"memory": "1932735232",
 			},
@@ -2031,7 +2031,7 @@ func TestKubeReservedResources(t *testing.T) {
 			mem:   8,
 			nc:    &ociv1beta1.OCINodeClass{},
 			want: map[string]string{
-				"cpu":    "72m",
+				"cpu": "72m",
 				// 8 GiB shape -> 0.20*(8-4)+1 = 1.8 GiB reserved, in bytes (float32)
 				"memory": "1932735232",
 			},
@@ -2051,7 +2051,7 @@ func TestKubeReservedResources(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"cpu":    "300m",
+				"cpu": "300m",
 				// 8 GiB shape -> 0.20*(8-4)+1 = 1.8 GiB reserved, in bytes (float32)
 				"memory": "1932735232",
 			},
@@ -2977,6 +2977,28 @@ func TestListInstanceTypes_NoDeadlockWithConcurrentWriter(t *testing.T) {
 	}
 }
 
+// setCapacity is where the distinction reaches the instance type, so assert it there too rather
+// than only on the helper.
+func TestSetCapacity_BareMetalVersusVM(t *testing.T) {
+	nc := &ociv1beta1.OCINodeClass{
+		Spec: ociv1beta1.OCINodeClassSpec{
+			VolumeConfig: &ociv1beta1.VolumeConfig{BootVolumeConfig: &ociv1beta1.BootVolumeConfig{}},
+		},
+	}
+
+	vm := &OciInstanceType{}
+	setCapacity(vm, vmShape, 4, 32, nc, ipV4SingleStack, defaultVMMemoryOverhead)
+
+	bm := &OciInstanceType{}
+	setCapacity(bm, bmShape, 4, 32, nc, ipV4SingleStack, defaultVMMemoryOverhead)
+
+	declared := resource.NewQuantity(32*1024*1024*1024, resource.BinarySI)
+	assert.Equal(t, declared.Value(), bm.Capacity.Memory().Value(),
+		"bare metal capacity must equal its declared memory")
+	assert.Less(t, vm.Capacity.Memory().Value(), declared.Value(),
+		"VM capacity must be reduced by the modelled hypervisor overhead")
+}
+
 func TestEvictionThreshold_PercentageUsesGiBBase(t *testing.T) {
 	// Regression for the 1024x unit error: resource.NewQuantity takes bytes, so a GiB figure
 	// must be scaled by 1024^3. Scaling by 1024^2 made every percentage-based threshold 1024x
@@ -3043,6 +3065,63 @@ func TestEvictionThreshold_ReadsSoftAndHardFromTheirOwnMaps(t *testing.T) {
 			assert.Equal(t, tt.wantDisk, ok, "ephemeral-storage threshold presence")
 		})
 	}
+}
+
+// The regression tests above call the helper directly, so they would still pass if the provider
+// stopped passing its configured overhead through. Drive the real call chain instead.
+func TestDecorateInstanceType_AppliesConfiguredOverhead(t *testing.T) {
+	nodeClass := &ociv1beta1.OCINodeClass{
+		Spec: ociv1beta1.OCINodeClassSpec{
+			VolumeConfig:  &ociv1beta1.VolumeConfig{BootVolumeConfig: &ociv1beta1.BootVolumeConfig{}},
+			NetworkConfig: &ociv1beta1.NetworkConfig{},
+		},
+	}
+	shapeAndAd := &ShapeAndAd{
+		Shape: &ocicore.Shape{
+			Shape: lo.ToPtr("VM.Standard.E4.Flex"), Ocpus: lo.ToPtr(float32(4)),
+			MemoryInGBs: lo.ToPtr(float32(32)), BillingType: ocicore.ShapeBillingTypePaid,
+		},
+		Ads: []string{"tenancy:PHX-AD-1"},
+	}
+	newProvider := func(overhead VMMemoryOverheadConfig) *DefaultProvider {
+		return &DefaultProvider{
+			shapeToPrice: map[string]*ShapePriceInfo{
+				"VM.STANDARD.E4.FLEX": {
+					ShapeName: lo.ToPtr("VM.Standard.E4.Flex"), OcpuUnitPrice: 0.05,
+					MemoryUnitPrice: 0.01, DiskUnitPrice: 0,
+				},
+			},
+			preemptibleShapes: PreemptibleShapes{"VM.STANDARD.E4": "VM.Standard.E4"},
+			vmMemoryOverhead:  overhead,
+		}
+	}
+	newInstanceType := func() *OciInstanceType {
+		return &OciInstanceType{
+			InstanceType: cloudprovider.InstanceType{Name: "VM.Standard.E4.Flex"},
+			Shape:        "VM.Standard.E4.Flex",
+			Ocpu:         lo.ToPtr(float32(4)),
+			MemoryInGbs:  lo.ToPtr(float32(32)),
+		}
+	}
+
+	declared := int64(32) * 1024 * 1024 * 1024
+
+	configured := newInstanceType()
+	_ = newProvider(defaultVMMemoryOverhead).decorateInstanceType(
+		context.Background(), configured, nodeClass, shapeAndAd, nil)
+
+	disabled := newInstanceType()
+	_ = newProvider(VMMemoryOverheadConfig{}).decorateInstanceType(
+		context.Background(), disabled, nodeClass, shapeAndAd, nil)
+
+	assert.Equal(t, declared, disabled.Capacity.Memory().Value(),
+		"a zero overhead must leave declared memory untouched")
+	assert.Less(t, configured.Capacity.Memory().Value(), declared,
+		"the provider's configured overhead must reach the modelled capacity")
+
+	wantMiB := memoryCapacityMiB(shapeAndAd.Shape, 32, defaultVMMemoryOverhead)
+	assert.Equal(t, wantMiB*1024*1024, configured.Capacity.Memory().Value(),
+		"the provider must apply exactly the configured overhead, not some other value")
 }
 
 func evictionTestNodeClass(hard, soft map[string]string) *ociv1beta1.OCINodeClass {

--- a/pkg/providers/instancetype/vm_memory_overhead.go
+++ b/pkg/providers/instancetype/vm_memory_overhead.go
@@ -1,0 +1,109 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package instancetype
+
+import (
+	"math"
+
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+)
+
+// Default VM memory overhead. These reserve at least as much as every measurement reported on
+// oracle/karpenter-provider-oci#7 (A1/E4/E5/Standard3, 8-128 GB), so the capacity derived from
+// them is a lower bound on what a node really has. They are the single source of truth for the
+// flag defaults in pkg/operator/options and the Helm chart; changing them changes what ships, so
+// TestMemoryCapacity_NeverOverEstimates asserts the safety property against these exact values.
+//
+// They are not the tightest fit to those measurements. The tightest lower bound clears the
+// closest point by only ~9 MiB, which is too little to survive a different image build or a
+// family we have not measured; these clear it by ~71 MiB and still reserve under 3 GiB on a
+// 128 GB shape, against 9.6 GiB for a flat 7.5%.
+const (
+	DefaultVMMemoryOverheadBaseMiB  = 600
+	DefaultVMMemoryOverheadPerGBMiB = 19
+	DefaultVMMemoryOverheadPercent  = 0
+)
+
+// VMMemoryOverheadConfig models the memory OCI reserves below the guest. A shape advertised as
+// N GB never presents a full N GiB of MemTotal to Linux, so modelling capacity as the declared
+// figure over-estimates what a node can hold. Karpenter has to make that estimate before the node
+// exists; when it is too high, the launched node cannot fit the pod that triggered it and — with
+// no feedback loop — the provisioning loop repeats indefinitely.
+//
+// The two failure modes are therefore wildly asymmetric: over-estimating costs an unbounded launch
+// loop, under-estimating costs a little wasted memory. These values are chosen to under-estimate.
+// They are a bootstrap guess only, and are expected to be superseded per shape+image by capacity
+// discovery once a launched node reports its real MemTotal.
+type VMMemoryOverheadConfig struct {
+	// BaseMiB is the fixed part of the overhead, in MiB.
+	BaseMiB float64
+	// PerGBMiB is the part that scales with declared memory, in MiB per GiB.
+	PerGBMiB float64
+	// Percent expresses the overhead as a fraction of declared memory (0.075 == 7.5%) instead of
+	// as a fixed and per-GiB amount. Zero disables it. When set, the larger of the two forms wins.
+	Percent float64
+}
+
+// OverheadMiB returns the memory overhead, in MiB, to subtract from a shape declaring gbs GiB.
+//
+// The fixed-plus-proportional form fits the observed behaviour far better than a flat percentage:
+// most of the reservation is fixed structure, with a small per-GiB page-table cost. A flat
+// percentage large enough to cover small shapes over-reserves badly on large ones.
+//
+// The percentage form is offered as an alternative way of expressing the same overhead, and is
+// combined with max() so that enabling it can only ever make the estimate more conservative.
+func (c VMMemoryOverheadConfig) OverheadMiB(gbs float64) int64 {
+	fixed := c.BaseMiB + c.PerGBMiB*gbs
+	percent := c.Percent * gbs * 1024
+
+	overhead := math.Ceil(math.Max(math.Max(fixed, percent), 0))
+
+	// Options validation rejects non-finite configuration, but converting a NaN or out-of-range
+	// float to int64 is implementation-defined in Go, so refuse to produce a garbage overhead
+	// here too. Falling back to the declared size means capacity clamps to its floor: useless,
+	// but never an over-estimate.
+	// Compared with >=, not >: float64(math.MaxInt64) rounds up to 2^63, which is one past the
+	// largest representable int64, so a > test would let exactly that value through to overflow.
+	if math.IsNaN(overhead) || overhead >= math.MaxInt64 {
+		return math.MaxInt64
+	}
+
+	return int64(overhead)
+}
+
+// memoryCapacityMiB returns the memory, in MiB, to report as a shape's capacity.
+//
+// The overhead is applied to capacity rather than to InstanceType.Overhead because it is not
+// reserved memory in the kubelet's sense — it is memory the guest never sees at all. Core's
+// InstanceTypeOverhead has slots only for KubeReserved, SystemReserved and EvictionThreshold,
+// none of which describes memory the guest never receives.
+//
+// Bare metal shapes keep their declared memory. The measurements behind the default, and the
+// mechanism they describe, are a hypervisor artefact; a BM instance has no hypervisor beneath it,
+// so subtracting a VM-derived figure there would shrink advertised capacity with nothing to
+// support it.
+func memoryCapacityMiB(shape *ocicore.Shape, gbs float32, vmMemoryOverhead VMMemoryOverheadConfig) int64 {
+	// Floor, not round: flexible shapes can declare a fractional number of GiB (memory is derived
+	// as ocpu * defaultPerOcpu / baselineFactor), and rounding 1.2 GiB up to 1229 MiB would report
+	// a shape as marginally larger than declared - the one direction this whole calculation exists
+	// to avoid. Whole-GiB shapes are unaffected.
+	declaredMiB := int64(math.Floor(float64(gbs) * 1024))
+
+	if shape != nil && shape.Shape != nil && IsBmShape(*shape.Shape) {
+		return declaredMiB
+	}
+
+	capacityMiB := declaredMiB - vmMemoryOverhead.OverheadMiB(float64(gbs))
+	if capacityMiB < 1 {
+		// Guard shapes small enough for the overhead to swallow the whole declaration. Such a
+		// shape cannot run a kubelet anyway, but capacity must stay positive.
+		return 1
+	}
+
+	return capacityMiB
+}

--- a/pkg/providers/instancetype/vm_memory_overhead_test.go
+++ b/pkg/providers/instancetype/vm_memory_overhead_test.go
@@ -1,0 +1,240 @@
+/*
+** Karpenter Provider OCI
+**
+** Copyright (c) 2026 Oracle and/or its affiliates.
+** Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+package instancetype
+
+import (
+	"fmt"
+	"testing"
+
+	ocicore "github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+// vmShape and bmShape stand in for the two cases the overhead distinguishes: the tax is a
+// hypervisor artefact, so it applies to virtual machines and not to bare metal.
+var (
+	vmShape = &ocicore.Shape{Shape: lo.ToPtr("VM.Standard.E5.Flex")}
+	bmShape = &ocicore.Shape{Shape: lo.ToPtr("BM.Standard.E5.192")}
+)
+
+// defaultVMMemoryOverhead is built from the shipped constants rather than a copy of them, so the
+// safety property below is asserted against what actually ships. pkg/operator/options and the Helm
+// chart are pinned to the same constants by TestVMMemoryOverheadDefaults*.
+var defaultVMMemoryOverhead = VMMemoryOverheadConfig{
+	BaseMiB:  DefaultVMMemoryOverheadBaseMiB,
+	PerGBMiB: DefaultVMMemoryOverheadPerGBMiB,
+	Percent:  DefaultVMMemoryOverheadPercent,
+}
+
+// publishedMeasurements are every measurement of OCI's VM memory overhead reported on
+// oracle/karpenter-provider-oci#7, across four CPU families and 8-128 GB. Both sources measure the
+// same quantity: the kubelet publishes /proc/meminfo MemTotal as node.status.capacity.memory.
+//
+//   - Ten in the issue body (A1, E4 and Standard3 at 8/50/128 GB, plus A1 at 12 GB), read from
+//     /proc/meminfo MemTotal:
+//     https://github.com/oracle/karpenter-provider-oci/issues/7
+//
+//   - Three in a follow-up comment (E5 at 16/28/32 GB), read from node.status.capacity.memory as
+//     reported by the kubelet:
+//     https://github.com/oracle/karpenter-provider-oci/issues/7#issuecomment-5320644834
+//     Collected on OKE Enhanced 1.35.2, Oracle Linux 9.8, VCN-native CNI, in ap-singapore-1, on
+//     VM.Standard.E5.Flex (AMD EPYC Genoa).
+//
+// The E5 rows matter disproportionately: they are the closest points to the default, and set its
+// 71 MiB safety margin. The other three families clear it by 175 MiB or more.
+//
+// The property that matters is that Karpenter's modelled capacity never exceeds the real
+// capacity. Exact agreement is neither achievable nor desirable: over-estimating makes Karpenter
+// launch a node the pending pod cannot fit on, and with no feedback loop it repeats that launch
+// indefinitely, while under-estimating merely wastes a little memory.
+var publishedMeasurements = []struct {
+	family      string
+	declaredMiB int64
+	actualMiB   int64
+}{
+	{"A1", 8192, 7657},
+	{"E4", 8192, 7646},
+	{"Std3", 8192, 7644},
+	{"A1", 12288, 11669},
+	{"E5", 16384, 15698},
+	{"E5", 28672, 27628},
+	{"E5", 32768, 31631},
+	{"A1", 51200, 49825},
+	{"E4", 51200, 49896},
+	{"Std3", 51200, 49894},
+	{"A1", 131072, 128292},
+	{"E4", 131072, 128286},
+	{"Std3", 131072, 128284},
+}
+
+// TestMemoryCapacity_NeverOverEstimates is the regression test for #7: the shipped defaults must
+// not over-estimate capacity against any published measurement.
+func TestMemoryCapacity_NeverOverEstimates(t *testing.T) {
+	for _, m := range publishedMeasurements {
+		t.Run(fmt.Sprintf("%s/%dMiB", m.family, m.declaredMiB), func(t *testing.T) {
+			gbs := float32(m.declaredMiB) / 1024
+			modelled := memoryCapacityMiB(vmShape, gbs, defaultVMMemoryOverhead)
+
+			// Clearing every measured point is necessary but not sufficient. These are 13 points
+			// from a handful of images; a default that clears the closest of them by a hair is
+			// one unmeasured image build away from over-estimating again. Require real headroom
+			// so that a future retune cannot quietly reintroduce the bug this test exists to
+			// catch, while staying far enough below the shipped margin (71 MiB) not to be brittle.
+			const minMarginMiB = 64
+
+			margin := m.actualMiB - modelled
+			assert.GreaterOrEqual(t, margin, int64(minMarginMiB),
+				"modelled capacity %d MiB leaves only %d MiB of headroom against measured capacity "+
+					"%d MiB for a %g GiB %s shape; below %d MiB an unmeasured image build could push "+
+					"real capacity under the model, and Karpenter would launch nodes too small for "+
+					"the pods that triggered them",
+				modelled, margin, m.actualMiB, gbs, m.family, minMarginMiB)
+
+			// The other direction: a safe estimate is still meant to be useful, so it should stay
+			// within 1 GiB of the real figure rather than throwing memory away.
+			assert.Less(t, margin, int64(1024),
+				"modelled capacity %d MiB under-estimates measured capacity %d MiB by more than 1 GiB",
+				modelled, m.actualMiB)
+		})
+	}
+}
+
+func TestMemoryCapacity_Defaults(t *testing.T) {
+	tests := []struct {
+		name string
+		gbs  float32
+		want int64
+	}{
+		// declared MiB - (600 + 19*GiB)
+		{"8 GiB", 8, 8192 - 752},
+		{"16 GiB", 16, 16384 - 904},
+		{"32 GiB", 32, 32768 - 1208},
+		{"128 GiB", 128, 131072 - 3032},
+		// Fractional declarations round the overhead up, never down: 600 + 19*1.5 = 628.5.
+		{"1.5 GiB", 1.5, 1536 - 629},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, memoryCapacityMiB(vmShape, tt.gbs, defaultVMMemoryOverhead))
+		})
+	}
+}
+
+func TestVMMemoryOverhead_PercentIsAFloor(t *testing.T) {
+	// The percentage is an alternative way of expressing the same overhead. Combining it with
+	// max() means enabling it can only ever make the estimate more conservative, never less.
+	fixedOnly := VMMemoryOverheadConfig{BaseMiB: 600, PerGBMiB: 19}
+	withPercent := VMMemoryOverheadConfig{BaseMiB: 600, PerGBMiB: 19, Percent: 0.075}
+
+	for _, gbs := range []float64{1, 8, 16, 32, 64, 128, 512} {
+		assert.GreaterOrEqual(t, withPercent.OverheadMiB(gbs), fixedOnly.OverheadMiB(gbs),
+			"adding a percentage must never reduce the overhead (gbs=%g)", gbs)
+	}
+
+	// 7.5% dominates on small shapes only once the shape is large enough; at 128 GiB the flat
+	// percentage reserves far more than the fitted form, which is why it is not the default.
+	assert.Equal(t, int64(9831), withPercent.OverheadMiB(128)) // 0.075*128*1024 = 9830.4, rounded up
+	assert.Equal(t, int64(3032), fixedOnly.OverheadMiB(128))
+}
+
+func TestMemoryCapacity_ClampsToPositive(t *testing.T) {
+	// A shape too small to survive the overhead must still report positive capacity.
+	huge := VMMemoryOverheadConfig{BaseMiB: 100000, PerGBMiB: 0}
+
+	assert.Equal(t, int64(1), memoryCapacityMiB(vmShape, 1, huge))
+	assert.Equal(t, int64(1), memoryCapacityMiB(vmShape, 0, huge))
+}
+
+func TestMemoryCapacity_ZeroOverheadIsDeclaredMemory(t *testing.T) {
+	// Setting the overhead to zero must actually disable it, restoring pre-#7 behaviour.
+	none := VMMemoryOverheadConfig{}
+
+	assert.Equal(t, int64(32768), memoryCapacityMiB(vmShape, 32, none))
+	assert.Equal(t, int64(0), none.OverheadMiB(32))
+}
+
+// The overhead models memory taken by a hypervisor. Bare metal has none, so applying a VM-derived
+// figure there would shrink advertised capacity with no evidence behind it.
+//
+// The table spans several BM families rather than one example: a gate written as an exact match on
+// a single shape name would satisfy a narrower test while still taxing every other BM family.
+func TestMemoryCapacity_BareMetalKeepsDeclaredMemory(t *testing.T) {
+	bmShapes := []string{
+		"BM.Standard.E5.192",
+		"BM.Standard3.64",
+		"BM.DenseIO.E5.128",
+		"BM.GPU.H100.8",
+		"BM.Optimized3.36",
+		"bm.standard.e5.192", // shape strings are matched case-insensitively
+	}
+	vmShapes := []string{
+		"VM.Standard.E5.Flex",
+		"VM.Standard.A1.Flex",
+		"VM.GPU.A10.2",
+		"VM.Optimized3.Flex",
+	}
+
+	for _, gbs := range []float32{8, 32, 128, 768} {
+		declared := int64(gbs) * 1024
+
+		for _, name := range bmShapes {
+			t.Run(fmt.Sprintf("%s/%gGiB", name, gbs), func(t *testing.T) {
+				shape := &ocicore.Shape{Shape: lo.ToPtr(name)}
+
+				assert.Equal(t, declared, memoryCapacityMiB(shape, gbs, defaultVMMemoryOverhead),
+					"bare metal must report its declared memory unchanged")
+			})
+		}
+
+		for _, name := range vmShapes {
+			t.Run(fmt.Sprintf("%s/%gGiB", name, gbs), func(t *testing.T) {
+				shape := &ocicore.Shape{Shape: lo.ToPtr(name)}
+
+				assert.Less(t, memoryCapacityMiB(shape, gbs, defaultVMMemoryOverhead), declared,
+					"a VM shape must still be adjusted for hypervisor overhead")
+			})
+		}
+	}
+}
+
+// A nil or unnamed shape must not panic, and must fall through to the VM path so that an
+// unidentifiable shape is treated conservatively rather than trusted at its declared size.
+func TestMemoryCapacity_NilShapeUsesVMPath(t *testing.T) {
+	declared := int64(32 * 1024)
+
+	assert.Less(t, memoryCapacityMiB(nil, 32, defaultVMMemoryOverhead), declared)
+	assert.Less(t, memoryCapacityMiB(&ocicore.Shape{}, 32, defaultVMMemoryOverhead), declared)
+}
+
+// Fractional GiB is reachable: flexible-shape memory is derived as
+// ocpu * defaultPerOcpuInGBs / baselineFactor. Declared memory must never round up, or a shape
+// would be modelled as marginally larger than it is.
+func TestMemoryCapacity_FractionalGiBRoundsDown(t *testing.T) {
+	tests := []struct {
+		gbs         float32
+		declaredMiB int64
+	}{
+		{1.2, 1228},   // exactly 1228.8 MiB
+		{2.5, 2560},   // MiB-aligned
+		{6.4, 6553},   // exactly 6553.6 MiB
+		{12.7, 13004}, // exactly 13004.8 MiB
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%gGiB", tt.gbs), func(t *testing.T) {
+			// Bare metal reports declared memory directly, so it isolates the rounding.
+			assert.Equal(t, tt.declaredMiB, memoryCapacityMiB(bmShape, tt.gbs, defaultVMMemoryOverhead),
+				"declared memory must be rounded down, never up")
+
+			assert.LessOrEqual(t, memoryCapacityMiB(vmShape, tt.gbs, defaultVMMemoryOverhead), tt.declaredMiB,
+				"a VM shape must never exceed declared memory either")
+		})
+	}
+}


### PR DESCRIPTION
# Description

OCI reserves memory below the guest, so a shape advertised as 32 GB presents roughly 30.89 GiB of `MemTotal` to Linux. KPO models memory capacity as the *declared* figure, so Karpenter over-estimates what a node can hold, launches a node the pending pod cannot fit on, and — having no feedback loop — repeats that launch indefinitely. #69 reported 50+ nodes in hours.

This subtracts a configurable overhead from modelled memory capacity:

```
overheadMiB = max(base + perGB × declaredGiB, percent × declaredMiB)
```

**Defaults are 600 MiB base and 19 MiB/GiB**, clearing every measurement published on #7 (A1/E4/E5/Standard3, 8–128 GB) by at least 71 MiB.

They are deliberately **not** the tightest fit. The tightest lower bound over the same 13 points is `570 + 18 × GB`, which clears the closest point by only 9 MiB — 0.03% of a 32 GB node, resting on one measurement from one image on one family. A different Oracle Linux build could erase that, and the safety property with it.

| fit | tightest margin | reserves @ 128 GB |
|---|---:|---:|
| 570 + 18 × GB | 9 MiB | 2.81 GiB |
| **600 + 19 × GB** (this PR) | **71 MiB** | **2.96 GiB** |
| 640 + 20 × GB | 143 MiB | 3.12 GiB |
| flat 7.5% (AWS default) | — | 9.60 GiB |

The headroom costs ~0.15 GiB on a 128 GB shape. Happy to move to `640 + 20` if reviewers prefer more margin.

## On the choice of an empirical constant

Raised in #7: OCI documents no hypervisor tax, so any figure here is empirical. Two things I'd offer:

1. `karpenter-provider-aws` ships [`VM_MEMORY_OVERHEAD_PERCENT = 0.075`](https://github.com/aws/karpenter-provider-aws/blob/7f27b4e85d3157418ab84eb04a3c91da7cb8fbba/pkg/operator/options/options.go#L66) on the same footing — [their docs](https://github.com/aws/karpenter-provider-aws/blob/7f27b4e85d3157418ab84eb04a3c91da7cb8fbba/website/content/en/docs/troubleshooting.md#L333-L341) state it is tuned empirically and cannot be computed ahead of time.
2. The failure modes are asymmetric — over-estimating causes an unbounded launch loop, under-estimating wastes a little memory — so what is needed is a **lower bound on real capacity**, not an accurate figure. That is a much weaker claim than documenting OCI's internals.

**This constant is a bootstrap value.** The real fix is capacity discovery: caching observed `node.status.capacity.memory` per shape + image after the first launch, as AWS does. The setting is shaped so a cache can simply take precedence over it later. I'd be glad to follow up with that if there's appetite.

## Design notes

- Applied to `InstanceType.Capacity`, not `InstanceType.Overhead` — core's `InstanceTypeOverhead` has slots only for `KubeReserved` / `SystemReserved` / `EvictionThreshold`, and this is not reserved memory in the kubelet's sense; the guest never sees it. This matches `karpenter-provider-aws`.
- Applied to all shapes including bare metal. BM has no hypervisor tax, so this is conservative there rather than accurate; happy to gate it on VM shapes if preferred.
- A percentage form is accepted for familiarity with the AWS provider, combined via `max()` so enabling it can only ever be more conservative.
- Defaults live as constants in `pkg/providers/instancetype` and are referenced by both the flags and the Helm chart, with tests pinning all three together so they cannot drift apart.
- The Helm template uses `kindIs "invalid"` rather than `with` for these numeric values: Go templates treat `0` as falsy, so `with` would silently discard an explicit `0` and fall back to the built-in default.

Fixes #7

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

Behaviour changes for existing users: modelled memory capacity drops by ~0.6–3 GiB per node. That is the point of the fix, but it may change instance-type selection. Setting all three values to `0` restores the previous behaviour exactly.

# How Has This Been Tested?

- [x] `TestMemoryCapacity_NeverOverEstimates` — asserts modelled capacity stays at least 64 MiB **below** measured capacity for all 13 published measurements. Headroom rather than mere non-exceedance, so the default cannot be retuned back to a hairline fit without failing.
- [x] `TestVMMemoryOverheadDefaults_MatchProviderConstants` / `_MatchHelmChart` — pin flag and chart defaults to the shared constants.
- [x] `TestMemoryCapacity_Defaults`, `_ClampsToPositive`, `_ZeroOverheadIsDeclaredMemory`, `TestVMMemoryOverhead_PercentIsAFloor` — arithmetic, clamping, opt-out, and the `max()` interaction.
- [x] `helm template` rendering verified for an explicitly-set `0`.
- [x] Full `go test ./pkg/...` passes, except `pkg/cloudprovider` and `pkg/controllers/nodeclasses`, which fail identically on unmodified `main` in my environment (missing envtest binaries at `bin/k8s`).

The 13 measurements are from #7 (10, reported by others) and my own comment on that issue (3):

- Kubernetes version: 1.35.2
- OKE version: Enhanced 1.35.2, Oracle Linux 9.8, VCN-native CNI
- Karpenter Provider OCI version: `main` @ 2359587
- Installation method: `helm`

Glad to run this against additional shapes, images or regions if there is coverage you'd want before trusting the default.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (chart values; happy to add a `docs/guide/` section if wanted)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

`go.mod` promotes `sigs.k8s.io/yaml` from indirect to direct (used by the chart-defaults test). No new modules.
