### PR TITLE
fix: correct evictionThreshold memory units and hard/soft field reads

### DIFF
--- a/pkg/providers/instancetype/provider.go
+++ b/pkg/providers/instancetype/provider.go
@@ -527,7 +527,11 @@ func evictionThreshold(gbs float32, class *ociv1beta1.OCINodeClass) v1.ResourceL
 		return nil
 	}
 
-	memory := resource.NewQuantity(int64(gbs*1024*1024), resource.BinarySI)
+	// resource.NewQuantity takes bytes, and gbs is in GiB, so the conversion is 1024^3.
+	// This previously scaled by 1024^2, making every percentage-based memory threshold 1024x
+	// too small and causing Karpenter to over-estimate allocatable memory by nearly the whole
+	// threshold.
+	memory := resource.NewQuantity(int64(float64(gbs)*1024*1024*1024), resource.BinarySI)
 
 	diskSizeAvailable := false
 	var storage *resource.Quantity
@@ -536,20 +540,24 @@ func evictionThreshold(gbs float32, class *ociv1beta1.OCINodeClass) v1.ResourceL
 		storage = resource.NewScaledQuantity(*class.Spec.VolumeConfig.BootVolumeConfig.SizeInGBs, resource.Giga)
 	}
 
+	// Each block reads its own map. Previously both read EvictionHard for memory and
+	// EvictionSoft for nodefs, so EvictionSoft[memory.available] and
+	// EvictionHard[nodefs.available] were never consulted, and a soft-only KubeletConfig
+	// produced no threshold at all.
 	hard := v1.ResourceList{}
 	if class.Spec.KubeletConfig.EvictionHard != nil {
 		if v, ok := class.Spec.KubeletConfig.EvictionHard[MemoryAvailable]; ok {
 			hard[v1.ResourceMemory] = parseEvictionSignal(memory, v)
 		}
 
-		if v, ok := class.Spec.KubeletConfig.EvictionSoft[NodeFSAvailable]; diskSizeAvailable && ok {
+		if v, ok := class.Spec.KubeletConfig.EvictionHard[NodeFSAvailable]; diskSizeAvailable && ok {
 			hard[v1.ResourceEphemeralStorage] = parseEvictionSignal(storage, v)
 		}
 	}
 
 	soft := v1.ResourceList{}
-	if class.Spec.KubeletConfig.EvictionHard != nil {
-		if v, ok := class.Spec.KubeletConfig.EvictionHard[MemoryAvailable]; ok {
+	if class.Spec.KubeletConfig.EvictionSoft != nil {
+		if v, ok := class.Spec.KubeletConfig.EvictionSoft[MemoryAvailable]; ok {
 			soft[v1.ResourceMemory] = parseEvictionSignal(memory, v)
 		}
 

--- a/pkg/providers/instancetype/provider_test.go
+++ b/pkg/providers/instancetype/provider_test.go
@@ -1827,7 +1827,7 @@ func TestEvictionThreshold(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"memory": "3355444", // 32Mi * 0.1 = 3,355,443.2 bytes, ceiled to 3,355,444
+				"memory": "3435973837", // 32Gi * 0.1 = 3,435,973,836.8 bytes, ceiled
 			},
 		},
 		{
@@ -1879,7 +1879,7 @@ func TestEvictionThreshold(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"memory":            "3355444",
+				"memory":            "3435973837",
 				"ephemeral-storage": "10000000000",
 			},
 		},
@@ -2942,5 +2942,86 @@ func TestListInstanceTypes_NoDeadlockWithConcurrentWriter(t *testing.T) {
 		close(stopWriter)
 		t.Fatal("ListInstanceTypes deadlocked with a concurrent writer: " +
 			"recursive p.lock.RLock in the ListInstanceTypes call chain")
+	}
+}
+
+func TestEvictionThreshold_PercentageUsesGiBBase(t *testing.T) {
+	// Regression for the 1024x unit error: resource.NewQuantity takes bytes, so a GiB figure
+	// must be scaled by 1024^3. Scaling by 1024^2 made every percentage-based threshold 1024x
+	// too small, which under-reports overhead and so over-estimates allocatable memory --
+	// the same failure mode that makes Karpenter relaunch nodes a pod can never fit on.
+	nc := evictionTestNodeClass(map[string]string{MemoryAvailable: "10%"}, nil)
+
+	got := evictionThreshold(32, nc)[v1.ResourceMemory]
+
+	pct := 0.10
+	want := int64(pct * float64(32*1024*1024*1024)) // 10% of 32 GiB, in bytes
+	assert.InDelta(t, want, got.Value(), float64(want)*0.001,
+		"expected ~%d bytes (3.2 GiB), got %d", want, got.Value())
+}
+
+func TestEvictionThreshold_AbsoluteSignalIgnoresBase(t *testing.T) {
+	// Absolute signals are parsed directly and must not depend on the memory base at all.
+	nc := evictionTestNodeClass(map[string]string{MemoryAvailable: "500Mi"}, nil)
+
+	got := evictionThreshold(32, nc)[v1.ResourceMemory]
+
+	assert.Equal(t, int64(500*1024*1024), got.Value())
+}
+
+func TestEvictionThreshold_ReadsSoftAndHardFromTheirOwnMaps(t *testing.T) {
+	// Both blocks previously read EvictionHard for memory and EvictionSoft for nodefs, so
+	// EvictionSoft[memory.available] and EvictionHard[nodefs.available] were never consulted.
+	tests := []struct {
+		name       string
+		hard, soft map[string]string
+		wantMemPct float64
+		wantDisk   bool
+	}{
+		{
+			name:       "soft memory larger than hard is respected",
+			hard:       map[string]string{MemoryAvailable: "1%"},
+			soft:       map[string]string{MemoryAvailable: "50%"},
+			wantMemPct: 0.50, // MaxResources picks the larger
+			wantDisk:   false,
+		},
+		{
+			name:       "hard nodefs is read",
+			hard:       map[string]string{MemoryAvailable: "10%", NodeFSAvailable: "10%"},
+			wantMemPct: 0.10,
+			wantDisk:   true,
+		},
+		{
+			name:       "soft-only config still produces a threshold",
+			soft:       map[string]string{MemoryAvailable: "10%", NodeFSAvailable: "10%"},
+			wantMemPct: 0.10,
+			wantDisk:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evictionThreshold(32, evictionTestNodeClass(tt.hard, tt.soft))
+
+			want := int64(tt.wantMemPct * float64(32*1024*1024*1024))
+			mem := got[v1.ResourceMemory]
+			assert.InDelta(t, want, mem.Value(), float64(want)*0.001)
+
+			_, ok := got[v1.ResourceEphemeralStorage]
+			assert.Equal(t, tt.wantDisk, ok, "ephemeral-storage threshold presence")
+		})
+	}
+}
+
+func evictionTestNodeClass(hard, soft map[string]string) *ociv1beta1.OCINodeClass {
+	return &ociv1beta1.OCINodeClass{
+		Spec: ociv1beta1.OCINodeClassSpec{
+			VolumeConfig: &ociv1beta1.VolumeConfig{
+				BootVolumeConfig: &ociv1beta1.BootVolumeConfig{
+					VolumeAttribute: ociv1beta1.VolumeAttribute{SizeInGBs: lo.ToPtr(int64(100))},
+				},
+			},
+			KubeletConfig: &ociv1beta1.KubeletConfiguration{EvictionHard: hard, EvictionSoft: soft},
+		},
 	}
 }


### PR DESCRIPTION
# Description

Fixes the 1024x unit error in `evictionThreshold()`, plus a second defect in the same function where the hard and soft branches read each other's maps.

`resource.NewQuantity` takes **bytes** and `gbs` is in GiB, so the conversion needs `1024³`; the code used `1024²`. Because the eviction threshold is part of `InstanceTypeOverhead` and core computes `allocatable = capacity - overhead.Total()`, under-reporting it **over-estimates allocatable memory** — ~3.2 GiB on a 32 GiB node at `memory.available: 10%`. Karpenter then launches a node the pending pod cannot fit on and, with no feedback loop, repeats indefinitely.

Only configs whose `evictionHard.memory.available` is a **percentage** are affected. Absolute values such as `500Mi` are parsed directly and were always correct.

Second defect: both branches read `EvictionHard` for memory and `EvictionSoft` for nodefs, so `EvictionSoft[memory.available]` and `EvictionHard[nodefs.available]` were never consulted, and a soft-only `kubeletConfig` produced no threshold at all. Since soft thresholds are normally set *higher* than hard ones, the `MaxResources(hard, soft)` that should have picked soft picked hard — under-reserving, same direction as the unit bug.

Fixes #74

## ⚠️ Two existing tests asserted the buggy values

`TestEvictionThreshold` had two cases expecting `"3355444"`, with a comment giving the misreading away:

```go
"memory": "3355444", // 32Mi * 0.1 = 3,355,443.2 bytes, ceiled to 3,355,444
```

That describes a 32 **GiB** node as "32Mi". Both are updated to `"3435973837"` in this PR. Calling it out explicitly so the test changes aren't mistaken for loosening tests to make the change pass — they are the point.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Behaviour change for affected users: modelled allocatable memory drops by the size of the intended threshold. That is the fix, but it may change instance-type selection for anyone currently using percentage-valued memory eviction signals. Users with absolute values see no change.

# How Has This Been Tested?

- [x] `TestEvictionThreshold_PercentageUsesGiBBase` — 10% of a 32 GiB node must be ~3.2 GiB, not 3.2 MiB
- [x] `TestEvictionThreshold_AbsoluteSignalIgnoresBase` — absolute signals must not depend on the base at all, so the fix cannot regress them
- [x] `TestEvictionThreshold_ReadsSoftAndHardFromTheirOwnMaps` — table covering soft memory larger than hard, hard nodefs, and a soft-only config
- [x] The two corrected existing cases in `TestEvictionThreshold`
- [x] Full `go test ./pkg/...` passes, except `pkg/cloudprovider` and `pkg/controllers/nodeclasses`, which fail identically on unmodified `main` in my environment (missing envtest binaries at `bin/k8s`)

- Kubernetes version: 1.35.2
- OKE version: Enhanced 1.35.2, Oracle Linux 9.8, VCN-native CNI
- Karpenter Provider OCI version: `main` @ `2359587`
- Installation method (`helm`, manifests, local run): `helm`

## Relationship to #73

Independent of #73 (hypervisor tax, #7) — different function, different trigger, additive effect. I have verified the two branches merge cleanly in either order, and that the merged tree builds and passes tests.

One judgement call left for whoever lands second: `evictionThreshold` computes its percentage off the raw declared `gbs`. After #73, modelled capacity is *lower* than declared, so a `10%` signal would model 10% of declared while the kubelet takes 10% of real `MemTotal` — over-reserving by ~0.1 GiB on a 32 GiB node. Safe direction and small, so not a blocker, and deliberately not changed here. Git will not surface it, because the two changes never touch the same lines.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — none needed; no user-facing API or setting changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
